### PR TITLE
fix: correct bats library loading paths for Ubuntu CI environment

### DIFF
--- a/.github/scripts/tests/setup-all.bats
+++ b/.github/scripts/tests/setup-all.bats
@@ -3,14 +3,20 @@
 # setup-all.sh のテスト
 
 # batsライブラリを環境に応じて読み込む
-# Ubuntu: /usr/lib/bats, macOS (Homebrew): /usr/local/lib/bats
-for path in /usr/lib/bats /usr/local/lib/bats /opt/homebrew/lib/bats; do
-    if [ -f "$path/bats-support/load" ]; then
-        load "$path/bats-support/load"
-        load "$path/bats-assert/load"
-        break
-    fi
-done
+# Ubuntu: /usr/lib/bats-support, macOS (Homebrew): /usr/local/lib/bats
+if [ -f "/usr/lib/bats-support/load.bash" ]; then
+    # Ubuntu (apt install bats-support bats-assert)
+    load "/usr/lib/bats-support/load.bash"
+    load "/usr/lib/bats-assert/load.bash"
+elif [ -f "/usr/local/lib/bats/bats-support/load" ]; then
+    # macOS Homebrew
+    load "/usr/local/lib/bats/bats-support/load"
+    load "/usr/local/lib/bats/bats-assert/load"
+elif [ -f "/opt/homebrew/lib/bats/bats-support/load" ]; then
+    # macOS Homebrew (Apple Silicon)
+    load "/opt/homebrew/lib/bats/bats-support/load"
+    load "/opt/homebrew/lib/bats/bats-assert/load"
+fi
 
 setup() {
     # テスト用の一時ディレクトリを作成

--- a/.github/scripts/tests/setup-branch-auto-delete.bats
+++ b/.github/scripts/tests/setup-branch-auto-delete.bats
@@ -3,14 +3,20 @@
 # setup-branch-auto-delete.sh のテスト
 
 # batsライブラリを環境に応じて読み込む
-# Ubuntu: /usr/lib/bats, macOS (Homebrew): /usr/local/lib/bats
-for path in /usr/lib/bats /usr/local/lib/bats /opt/homebrew/lib/bats; do
-    if [ -f "$path/bats-support/load" ]; then
-        load "$path/bats-support/load"
-        load "$path/bats-assert/load"
-        break
-    fi
-done
+# Ubuntu: /usr/lib/bats-support, macOS (Homebrew): /usr/local/lib/bats
+if [ -f "/usr/lib/bats-support/load.bash" ]; then
+    # Ubuntu (apt install bats-support bats-assert)
+    load "/usr/lib/bats-support/load.bash"
+    load "/usr/lib/bats-assert/load.bash"
+elif [ -f "/usr/local/lib/bats/bats-support/load" ]; then
+    # macOS Homebrew
+    load "/usr/local/lib/bats/bats-support/load"
+    load "/usr/local/lib/bats/bats-assert/load"
+elif [ -f "/opt/homebrew/lib/bats/bats-support/load" ]; then
+    # macOS Homebrew (Apple Silicon)
+    load "/opt/homebrew/lib/bats/bats-support/load"
+    load "/opt/homebrew/lib/bats/bats-assert/load"
+fi
 
 setup() {
     # テスト用の一時ディレクトリを作成

--- a/.github/scripts/tests/setup-github-project.bats
+++ b/.github/scripts/tests/setup-github-project.bats
@@ -3,14 +3,20 @@
 # setup-github-project.sh のテスト
 
 # batsライブラリを環境に応じて読み込む
-# Ubuntu: /usr/lib/bats, macOS (Homebrew): /usr/local/lib/bats
-for path in /usr/lib/bats /usr/local/lib/bats /opt/homebrew/lib/bats; do
-    if [ -f "$path/bats-support/load" ]; then
-        load "$path/bats-support/load"
-        load "$path/bats-assert/load"
-        break
-    fi
-done
+# Ubuntu: /usr/lib/bats-support, macOS (Homebrew): /usr/local/lib/bats
+if [ -f "/usr/lib/bats-support/load.bash" ]; then
+    # Ubuntu (apt install bats-support bats-assert)
+    load "/usr/lib/bats-support/load.bash"
+    load "/usr/lib/bats-assert/load.bash"
+elif [ -f "/usr/local/lib/bats/bats-support/load" ]; then
+    # macOS Homebrew
+    load "/usr/local/lib/bats/bats-support/load"
+    load "/usr/local/lib/bats/bats-assert/load"
+elif [ -f "/opt/homebrew/lib/bats/bats-support/load" ]; then
+    # macOS Homebrew (Apple Silicon)
+    load "/opt/homebrew/lib/bats/bats-support/load"
+    load "/opt/homebrew/lib/bats/bats-assert/load"
+fi
 
 setup() {
     # テスト用の一時ディレクトリを作成

--- a/.github/scripts/tests/setup-labels.bats
+++ b/.github/scripts/tests/setup-labels.bats
@@ -3,14 +3,20 @@
 # setup-labels.sh のテスト
 
 # batsライブラリを環境に応じて読み込む
-# Ubuntu: /usr/lib/bats, macOS (Homebrew): /usr/local/lib/bats
-for path in /usr/lib/bats /usr/local/lib/bats /opt/homebrew/lib/bats; do
-    if [ -f "$path/bats-support/load" ]; then
-        load "$path/bats-support/load"
-        load "$path/bats-assert/load"
-        break
-    fi
-done
+# Ubuntu: /usr/lib/bats-support, macOS (Homebrew): /usr/local/lib/bats
+if [ -f "/usr/lib/bats-support/load.bash" ]; then
+    # Ubuntu (apt install bats-support bats-assert)
+    load "/usr/lib/bats-support/load.bash"
+    load "/usr/lib/bats-assert/load.bash"
+elif [ -f "/usr/local/lib/bats/bats-support/load" ]; then
+    # macOS Homebrew
+    load "/usr/local/lib/bats/bats-support/load"
+    load "/usr/local/lib/bats/bats-assert/load"
+elif [ -f "/opt/homebrew/lib/bats/bats-support/load" ]; then
+    # macOS Homebrew (Apple Silicon)
+    load "/opt/homebrew/lib/bats/bats-support/load"
+    load "/opt/homebrew/lib/bats/bats-assert/load"
+fi
 
 setup() {
     # テスト用の一時ディレクトリを作成

--- a/.github/scripts/tests/setup-rulesets.bats
+++ b/.github/scripts/tests/setup-rulesets.bats
@@ -3,21 +3,28 @@
 # setup-rulesets.sh のテスト
 
 # batsライブラリを環境に応じて読み込む
-# Ubuntu: /usr/lib/bats, macOS (Homebrew): /usr/local/lib/bats
-for path in /usr/lib/bats /usr/local/lib/bats /opt/homebrew/lib/bats; do
-    if [ -f "$path/bats-support/load" ]; then
-        load "$path/bats-support/load"
-        load "$path/bats-assert/load"
-        break
-    fi
-done
+# Ubuntu: /usr/lib/bats-support, macOS (Homebrew): /usr/local/lib/bats
+if [ -f "/usr/lib/bats-support/load.bash" ]; then
+    # Ubuntu (apt install bats-support bats-assert)
+    load "/usr/lib/bats-support/load.bash"
+    load "/usr/lib/bats-assert/load.bash"
+elif [ -f "/usr/local/lib/bats/bats-support/load" ]; then
+    # macOS Homebrew
+    load "/usr/local/lib/bats/bats-support/load"
+    load "/usr/local/lib/bats/bats-assert/load"
+elif [ -f "/opt/homebrew/lib/bats/bats-support/load" ]; then
+    # macOS Homebrew (Apple Silicon)
+    load "/opt/homebrew/lib/bats/bats-support/load"
+    load "/opt/homebrew/lib/bats/bats-assert/load"
+fi
 
 setup() {
     # テスト用の一時ディレクトリを作成
     TEST_DIR=$(mktemp -d)
-    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-    RULESETS_DIR="$(cd "$SCRIPT_DIR/../rulesets" && pwd)"
-    
+    # batsテストファイルからの相対パスを正しく解決
+    SCRIPT_DIR="$(cd "$(dirname "${BATS_TEST_FILENAME}")/.." && pwd)"
+    RULESETS_DIR="$SCRIPT_DIR/../rulesets"
+
     # モック用のパスを設定
     export PATH="$TEST_DIR:$PATH"
     


### PR DESCRIPTION
The BATS test files were using incorrect paths for loading bats-support and bats-assert libraries. In Ubuntu 22.04 (used by GitHub Actions), these libraries are installed directly in /usr/lib/bats-support and /usr/lib/bats-assert, not in /usr/lib/bats.

Changes:
- Updated library loading logic to check Ubuntu paths first (/usr/lib/bats-support/load.bash)
- Added fallback paths for macOS Homebrew installations
- Fixed setup-rulesets.bats RULESETS_DIR calculation to use BATS_TEST_FILENAME instead of BASH_SOURCE

This resolves the "command not found" errors for assert, assert_success, and assert_failure commands in all test files.

## Description

<!-- 変更内容の説明を記述してください -->

## Type of Change

<!-- 該当するものを選択してください -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Related Issues

<!-- 関連するIssueがあれば記述してください -->
<!-- 例: Closes #123, Fixes #456 -->

## Changes Made

<!-- 具体的な変更内容を記述してください -->

- 
- 

## Testing

<!-- テスト方法や確認事項を記述してください -->

- [ ] テストを追加/更新しました
- [ ] 既存のテストがすべて通過します
- [ ] 手動で動作確認しました

## Checklist

<!-- 提出前に確認してください -->

- [ ] コードはプロジェクトのスタイルガイドに従っています
- [ ] 自己レビューを実施しました
- [ ] コメントを適切に追加しました（特に複雑な部分）
- [ ] 関連するドキュメントを更新しました
- [ ] 変更によって新しい警告は発生していません
- [ ] テストを追加/更新しました
- [ ] すべてのテストが通過します

## Screenshots (if applicable)

<!-- UI変更がある場合はスクリーンショットを追加してください -->

## Additional Notes

<!-- その他の注意事項があれば記述してください -->

## Summary by Sourcery

Fix Bats-based CI test scripts to correctly locate support/assert libraries across Ubuntu and macOS environments.

Bug Fixes:
- Resolve failures in Bats tests on Ubuntu by loading bats-support and bats-assert from their actual installation paths.
- Correct RULESETS_DIR resolution in setup-rulesets.bats so ruleset paths are derived from the test file location instead of BASH_SOURCE.

Tests:
- Align Bats test library loading paths for both Ubuntu (apt) and macOS Homebrew installations to ensure consistent test execution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test setup infrastructure with explicit, OS-specific library detection for improved cross-platform reliability across Ubuntu and macOS (Intel and Apple Silicon) environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->