### PR TITLE
feat: add OpenCode GitHub Actions workflow

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -1,41 +1,31 @@
-name: OpenCode
+name: opencode
 
 on:
   issue_comment:
     types: [created]
-  pull_request_review:
-    types: [submitted]
   pull_request_review_comment:
     types: [created]
-
-permissions:
-  contents: write
-  pull-requests: write
-  issues: write
 
 jobs:
   opencode:
     if: |
-      (github.event_name == 'issue_comment' && (contains(github.event.comment.body, '/opencode') || contains(github.event.comment.body, '/oc'))) ||
-      (github.event_name == 'pull_request_review_comment' && (contains(github.event.comment.body, '/opencode') || contains(github.event.comment.body, '/oc'))) ||
-      (github.event_name == 'pull_request_review' && (contains(github.event.review.body, '/opencode') || contains(github.event.review.body, '/oc')))
+      contains(github.event.comment.body, '/oc') ||
+      contains(github.event.comment.body, '/opencode')
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Install OpenCode CLI
-        run: |
-          curl -L -o opencode.tar.gz https://github.com/opencode-ai/opencode/releases/latest/download/opencode-linux-x86_64.tar.gz
-          tar -xzf opencode.tar.gz
-          sudo mv opencode /usr/local/bin/opencode
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          persist-credentials: false
 
       - name: Run OpenCode
+        uses: anomalyco/opencode/github@latest
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          opencode github run \
-            --event "$GITHUB_EVENT_PATH" \
-            --token "$GITHUB_TOKEN" \
-            --model "openai/gpt-4o-mini" \
-            --agent "build"
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        with:
+          model: anthropic/claude-sonnet-4-20250514
+          # share: true
+          # github_token: xxxx


### PR DESCRIPTION
### Motivation
- Enable running OpenCode from issue/PR comments so repository contributors can invoke the OpenCode agent with `/opencode` or `/oc` (addresses Issue #41).

### Description
- Add `​.github/workflows/opencode.yml` which triggers on `issue_comment`, `pull_request_review`, and `pull_request_review_comment` and gates execution when the comment body contains `/opencode` or `/oc`.
- Configure workflow permissions (`contents: write`, `pull-requests: write`, `issues: write`), install the OpenCode CLI, and run `opencode github run` with `--model "openai/gpt-4o-mini"` and `--agent "build"`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b03c4168c832da5c19e10a2bc6165)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added comment-triggered automation: issue and review comments with "/oc" or "/opencode" now invoke automated AI-powered processing.
  * Deployment handles authentication and execution transparently so contributors can trigger checks via comments without extra setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->