### PR TITLE
Add error handling to .github/scripts/setup-all.sh

### DIFF
--- a/.github/scripts/setup-all.sh
+++ b/.github/scripts/setup-all.sh
@@ -2,8 +2,6 @@
 
 # すべての GitHub 設定を一括でセットアップするスクリプト
 
-set -e
-
 # Dry-run モード（環境変数 DRY_RUN=1 で有効化）
 DRY_RUN=${DRY_RUN:-0}
 export DRY_RUN
@@ -18,29 +16,49 @@ if [ "$DRY_RUN" = "1" ]; then
 fi
 echo ""
 
-# Ruleset のセットアップ
-echo "1. Ruleset のセットアップを実行します..."
-bash "$SCRIPT_DIR/setup-rulesets.sh"
-echo ""
+declare -a SUCCESS_SCRIPTS=()
+declare -a FAILED_SCRIPTS=()
 
-# ブランチ自動削除の設定
-echo "2. ブランチ自動削除の設定を実行します..."
-bash "$SCRIPT_DIR/setup-branch-auto-delete.sh"
-echo ""
+run_script() {
+  local number="$1"
+  local name="$2"
+  local script="$3"
 
-# PRブランチ更新提案の設定
-echo "3. PRブランチ更新提案の設定を実行します..."
-bash "$SCRIPT_DIR/setup-branch-update-suggestion.sh"
-echo ""
+  echo "${number}. ${name} を実行します..."
+  if bash "$script"; then
+    SUCCESS_SCRIPTS+=("$name")
+    echo "✓ ${name} が完了しました"
+  else
+    FAILED_SCRIPTS+=("$name")
+    echo "✗ ${name} が失敗しました"
+  fi
+  echo ""
+}
 
-# ラベルの設定
-echo "4. ラベルの設定を実行します..."
-bash "$SCRIPT_DIR/setup-labels.sh"
-echo ""
+run_script "1" "Ruleset のセットアップ" "$SCRIPT_DIR/setup-rulesets.sh"
+run_script "2" "ブランチ自動削除の設定" "$SCRIPT_DIR/setup-branch-auto-delete.sh"
+run_script "3" "PRブランチ更新提案の設定" "$SCRIPT_DIR/setup-branch-update-suggestion.sh"
+run_script "4" "ラベルの設定" "$SCRIPT_DIR/setup-labels.sh"
+run_script "5" "GitHub Project のセットアップ" "$SCRIPT_DIR/setup-github-project.sh"
 
-# GitHub Project のセットアップ
-echo "5. GitHub Project のセットアップを実行します..."
-bash "$SCRIPT_DIR/setup-github-project.sh"
-echo ""
+echo "=============================="
+echo "実行結果サマリー"
+echo "=============================="
+echo "成功: ${#SUCCESS_SCRIPTS[@]}"
+for script in "${SUCCESS_SCRIPTS[@]}"; do
+  echo "  ✓ ${script}"
+done
 
+if [ ${#FAILED_SCRIPTS[@]} -gt 0 ]; then
+  echo ""
+  echo "失敗: ${#FAILED_SCRIPTS[@]}"
+  for script in "${FAILED_SCRIPTS[@]}"; do
+    echo "  ✗ ${script}"
+  done
+  echo ""
+  echo "一部のセットアップが失敗しました"
+  exit 1
+fi
+
+echo ""
 echo "すべてのセットアップが完了しました！"


### PR DESCRIPTION
### Motivation

- The original `setup-all.sh` used `set -e`, which aborted the whole run when any step failed and prevented subsequent setup scripts from running.
- The change aims to ensure each sub-script runs regardless of failures, record per-step results, and surface a final success/failure summary.

### Description

- Removed the global `set -e` from `.github/scripts/setup-all.sh` to avoid early termination of the whole process.
- Added `SUCCESS_SCRIPTS` and `FAILED_SCRIPTS` arrays and a `run_script` helper to run each sub-script while recording outcomes.
- Replaced inline `bash` invocations with `run_script` calls for `setup-rulesets.sh`, `setup-branch-auto-delete.sh`, `setup-branch-update-suggestion.sh`, `setup-labels.sh`, and `setup-github-project.sh`.
- Emit a summary of successes and failures and `exit 1` if any step failed while preserving the `DRY_RUN` behavior.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c5779ec10832dad11ab70c0f5ed07)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved setup reliability and diagnostic capabilities. The initialization process better organizes and standardizes all configuration steps with comprehensive logging and outcome tracking. A detailed execution summary now displays which configurations succeeded and which encountered issues, helping users quickly identify and troubleshoot any problems during the initial system setup and configuration process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->