### PR TITLE
feat: add .codex/hooks setup scripts (Closes #65)

### DIFF
--- a/.codex/hooks/env-setup.sh
+++ b/.codex/hooks/env-setup.sh
@@ -1,0 +1,289 @@
+#!/bin/bash
+# This is sample script, and you should verify your own.
+# SessionStart hook: setup a shell development environment for Codex
+# Mirrors Dockerfile setup (shellcheck, Go, shfmt, actionlint, Node.js, Prettier,
+# and helper lint scripts). Designed to be idempotent and fail-safe.
+
+LOG_PREFIX="[codex-env-setup]"
+
+log() {
+  echo "$LOG_PREFIX $1" >&2
+}
+
+LOCAL_BIN="$HOME/.local/bin"
+GO_VERSION="1.23.5"
+GO_ROOT="$HOME/.local/go"
+GO_TARBALL_DIR="$HOME/.local/tmp/go-install"
+GOPATH="$HOME/.local/go-path"
+
+mkdir -p "$LOCAL_BIN" "$GOPATH"
+
+add_to_path() {
+  local dir="$1"
+  if [[ ":$PATH:" != *":$dir:"* ]]; then
+    export PATH="$dir:$PATH"
+  fi
+}
+
+persist_path() {
+  local dir="$1"
+  local export_line="export PATH=\"$dir:\$PATH\""
+  if [ -n "${CODEX_ENV_FILE:-}" ]; then
+    touch "$CODEX_ENV_FILE"
+    if ! grep -Fxq "$export_line" "$CODEX_ENV_FILE"; then
+      echo "$export_line" >>"$CODEX_ENV_FILE"
+      log "PATH persisted to CODEX_ENV_FILE ($dir)"
+    fi
+  fi
+}
+
+add_to_path "$LOCAL_BIN"
+add_to_path "$GO_ROOT/bin"
+
+persist_path "$LOCAL_BIN"
+persist_path "$GO_ROOT/bin"
+
+install_packages() {
+  if ! command -v apt-get &>/dev/null; then
+    log "apt-get not available; skipping package installation"
+    return 0
+  fi
+
+  local packages=()
+
+  if ! command -v shellcheck &>/dev/null; then
+    packages+=(shellcheck)
+  fi
+  if ! command -v wget &>/dev/null; then
+    packages+=(wget)
+  fi
+  if ! command -v git &>/dev/null; then
+    packages+=(git)
+  fi
+  if ! command -v bats &>/dev/null; then
+    packages+=(bats)
+  fi
+  if ! command -v curl &>/dev/null; then
+    packages+=(curl)
+  fi
+  if ! command -v node &>/dev/null; then
+    packages+=(nodejs)
+  fi
+  if ! command -v npm &>/dev/null; then
+    packages+=(npm)
+  fi
+
+  if [ "${#packages[@]}" -eq 0 ]; then
+    log "System packages already installed"
+    return 0
+  fi
+
+  local sudo_cmd=""
+  if [ "$(id -u)" -ne 0 ]; then
+    if command -v sudo &>/dev/null; then
+      sudo_cmd="sudo"
+    else
+      log "sudo not available; skipping package installation"
+      return 0
+    fi
+  fi
+
+  log "Installing packages: ${packages[*]}"
+  if ! $sudo_cmd apt-get update; then
+    log "apt-get update failed; skipping package installation"
+    return 0
+  fi
+  if ! $sudo_cmd apt-get install -y "${packages[@]}"; then
+    log "apt-get install failed; skipping package installation"
+    return 0
+  fi
+}
+
+install_go() {
+  if command -v go &>/dev/null; then
+    local current_version
+    current_version=$(go version | awk '{print $3}' | sed 's/^go//')
+    if [[ "$current_version" == "$GO_VERSION" || "$current_version" == 1.23* ]]; then
+      log "Go already installed: $current_version"
+      return 0
+    fi
+    log "Go version $current_version found; upgrading to $GO_VERSION"
+  fi
+
+  local arch
+  arch=$(uname -m)
+  case "$arch" in
+  x86_64)
+    arch="amd64"
+    ;;
+  aarch64 | arm64)
+    arch="arm64"
+    ;;
+  *)
+    log "Unsupported architecture for Go: $arch"
+    return 0
+    ;;
+  esac
+
+  local tarball="go${GO_VERSION}.linux-${arch}.tar.gz"
+  local url="https://go.dev/dl/${tarball}"
+
+  mkdir -p "$GO_TARBALL_DIR"
+  rm -rf "$GO_TARBALL_DIR"/*
+
+  log "Downloading Go ${GO_VERSION} for ${arch}..."
+  if command -v curl &>/dev/null; then
+    if ! curl -fsSL "$url" -o "$GO_TARBALL_DIR/$tarball"; then
+      log "Failed to download Go with curl"
+      return 0
+    fi
+  elif command -v wget &>/dev/null; then
+    if ! wget -qO "$GO_TARBALL_DIR/$tarball" "$url"; then
+      log "Failed to download Go with wget"
+      return 0
+    fi
+  else
+    log "Neither curl nor wget available for Go download"
+    return 0
+  fi
+
+  log "Extracting Go..."
+  rm -rf "$GO_ROOT"
+  mkdir -p "$GO_ROOT"
+  if ! tar -xzf "$GO_TARBALL_DIR/$tarball" -C "$GO_TARBALL_DIR"; then
+    log "Failed to extract Go tarball"
+    return 0
+  fi
+  if ! mv "$GO_TARBALL_DIR/go" "$GO_ROOT"; then
+    log "Failed to install Go"
+    return 0
+  fi
+
+  add_to_path "$GO_ROOT/bin"
+  persist_path "$GO_ROOT/bin"
+  log "Go installed: $GO_VERSION"
+}
+
+install_shfmt() {
+  local required_version="v3.12.0"
+  if command -v shfmt &>/dev/null; then
+    local current
+    current=$(shfmt --version 2>/dev/null)
+    if [ "$current" = "$required_version" ]; then
+      log "shfmt already installed: $current"
+      return 0
+    fi
+  fi
+
+  if ! command -v go &>/dev/null; then
+    log "Go not available; skipping shfmt installation"
+    return 0
+  fi
+
+  log "Installing shfmt $required_version..."
+  if ! GOBIN="$LOCAL_BIN" GOPATH="$GOPATH" go install mvdan.cc/sh/v3/cmd/shfmt@${required_version}; then
+    log "Failed to install shfmt"
+    return 0
+  fi
+}
+
+install_actionlint() {
+  local required_version="1.7.5"
+  if command -v actionlint &>/dev/null; then
+    local current
+    current=$(actionlint -version 2>/dev/null | awk '{print $3}')
+    if [ "$current" = "$required_version" ]; then
+      log "actionlint already installed: $current"
+      return 0
+    fi
+  fi
+
+  if ! command -v go &>/dev/null; then
+    log "Go not available; skipping actionlint installation"
+    return 0
+  fi
+
+  log "Installing actionlint $required_version..."
+  if ! GOBIN="$LOCAL_BIN" GOPATH="$GOPATH" go install github.com/rhysd/actionlint/cmd/actionlint@v${required_version}; then
+    log "Failed to install actionlint"
+    return 0
+  fi
+}
+
+install_prettier() {
+  local required_version="3.4.2"
+  if command -v prettier &>/dev/null; then
+    local current
+    current=$(prettier --version 2>/dev/null)
+    if [ "$current" = "$required_version" ]; then
+      log "Prettier already installed: $current"
+      return 0
+    fi
+  fi
+
+  if ! command -v npm &>/dev/null; then
+    log "npm not available; skipping Prettier installation"
+    return 0
+  fi
+
+  log "Installing Prettier $required_version..."
+  if ! npm install -g "prettier@${required_version}"; then
+    log "Failed to install Prettier"
+    return 0
+  fi
+}
+
+install_lint_scripts() {
+  local lint_shell="$LOCAL_BIN/lint-shell"
+  local lint_docs="$LOCAL_BIN/lint-docs"
+
+  cat <<'SCRIPT' >"$lint_shell"
+#!/bin/bash
+set -e
+
+echo "Running shellcheck..."
+find . -name "*.sh" -type f -print0 | xargs -0 shellcheck --severity=warning
+
+echo ""
+echo "Running shfmt..."
+find . -name "*.sh" -not -name "*.bats" -type f -print0 | xargs -0 shfmt -i 2 -d
+
+echo ""
+echo "All linting checks passed!"
+SCRIPT
+
+  chmod +x "$lint_shell"
+
+  cat <<'SCRIPT' >"$lint_docs"
+#!/bin/bash
+set -e
+
+echo "Running Prettier (Markdown)..."
+prettier --check "README.md" "AGENTS.md" "CLAUDE.md" "docs/**/*.md" ".github/**/*.md"
+
+echo ""
+echo "Running Prettier (YAML)..."
+prettier --check "compose.yml" "codecov.yml" ".github/**/*.{yml,yaml}"
+
+echo ""
+echo "Running Prettier (JSON)..."
+prettier --check ".github/**/*.json"
+
+echo ""
+echo "All document linting checks passed!"
+SCRIPT
+
+  chmod +x "$lint_docs"
+
+  log "Helper scripts installed to $LOCAL_BIN"
+}
+
+log "Starting Codex environment setup..."
+install_packages
+install_go
+install_shfmt
+install_actionlint
+install_prettier
+install_lint_scripts
+log "Codex environment setup completed"
+exit 0

--- a/.codex/hooks/gh-setup.sh
+++ b/.codex/hooks/gh-setup.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+# This is sample script, and you should verify your own.
+# SessionStart hook: GitHub CLI auto-installation for Codex environments
+# This script installs gh CLI following best practices: idempotent, fail-safe,
+# and proper logging.
+
+set -e
+
+LOG_PREFIX="[codex-gh-setup]"
+
+log() {
+  echo "$LOG_PREFIX $1" >&2
+}
+
+if [ "${CODEX_REMOTE:-}" != "true" ] && [ "${CODEX_CONTAINER:-}" != "true" ]; then
+  log "Codex remote flag not detected; continuing gh setup"
+fi
+
+log "Checking gh CLI..."
+
+if command -v gh &>/dev/null; then
+  log "gh CLI already available: $(gh --version | head -1)"
+  exit 0
+fi
+
+LOCAL_BIN="$HOME/.local/bin"
+mkdir -p "$LOCAL_BIN"
+
+if [ -x "$LOCAL_BIN/gh" ]; then
+  log "gh found in $LOCAL_BIN"
+  if [[ ":$PATH:" != *":$LOCAL_BIN:"* ]]; then
+    export PATH="$LOCAL_BIN:$PATH"
+    if [ -n "${CODEX_ENV_FILE:-}" ]; then
+      echo "export PATH=\"$LOCAL_BIN:\$PATH\"" >>"$CODEX_ENV_FILE"
+      log "PATH updated in CODEX_ENV_FILE"
+    fi
+  fi
+  exit 0
+fi
+
+log "Installing gh CLI to $LOCAL_BIN..."
+
+TEMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TEMP_DIR"' EXIT
+
+ARCH=$(uname -m)
+case "$ARCH" in
+x86_64)
+  GH_ARCH="amd64"
+  ;;
+aarch64 | arm64)
+  GH_ARCH="arm64"
+  ;;
+*)
+  log "Unsupported architecture: $ARCH"
+  exit 0
+  ;;
+esac
+
+GH_VERSION="2.62.0"
+GH_TARBALL="gh_${GH_VERSION}_linux_${GH_ARCH}.tar.gz"
+GH_URL="https://github.com/cli/cli/releases/download/v${GH_VERSION}/${GH_TARBALL}"
+
+log "Downloading gh v${GH_VERSION} for ${GH_ARCH}..."
+
+if ! curl -sL "$GH_URL" -o "$TEMP_DIR/$GH_TARBALL"; then
+  log "Failed to download gh CLI"
+  exit 0
+fi
+
+log "Extracting..."
+if ! tar -xzf "$TEMP_DIR/$GH_TARBALL" -C "$TEMP_DIR"; then
+  log "Failed to extract gh CLI"
+  exit 0
+fi
+
+if ! mv "$TEMP_DIR/gh_${GH_VERSION}_linux_${GH_ARCH}/bin/gh" "$LOCAL_BIN/gh"; then
+  log "Failed to install gh CLI"
+  exit 0
+fi
+
+chmod +x "$LOCAL_BIN/gh"
+
+export PATH="$LOCAL_BIN:$PATH"
+
+if [ -n "${CODEX_ENV_FILE:-}" ]; then
+  echo "export PATH=\"$LOCAL_BIN:\$PATH\"" >>"$CODEX_ENV_FILE"
+  log "PATH persisted to CODEX_ENV_FILE"
+fi
+
+log "gh CLI installed successfully: $($LOCAL_BIN/gh --version | head -1)"
+exit 0


### PR DESCRIPTION
### Motivation

- Closes #65 to provide Codex-specific setup comparable to existing `./.claude/hooks` scripts.  
- Codex runs inside a container and cannot rely on Docker-based provisioning, so user-space scripts are required to bootstrap tooling and the `gh` CLI.

### Description

- Add `./.codex/hooks/gh-setup.sh` which installs the GitHub CLI (`gh`) in a user-local bin, updates `PATH`, and persists the change to `CODEX_ENV_FILE` when present, with idempotent and fail-safe behavior.  
- Add `./.codex/hooks/env-setup.sh` which bootstraps development tooling (Go `1.23.5`, `shfmt` v3.12.0 via `go install`, `actionlint` v1.7.5 via `go install`, `prettier` v3.4.2 via `npm`, and system packages like `shellcheck`), creates helper lint scripts (`lint-shell` and `lint-docs`), and includes PATH management and persistence; all steps are designed to be idempotent and to skip gracefully when prerequisites are missing.  
- Both scripts detect architecture, provide clear logging, and avoid failing the session on unsupported environments (fail-safe design).  

### Testing

- No automated tests were added or executed for these scripts in this change.  
- The scripts were created and committed to the repository and are ready for manual / CI validation in target Codex environments.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69757fb33dc4832dbbc4d881dfabe696)

## Summary by Sourcery

Add Codex SessionStart hook scripts to bootstrap a local development environment and GitHub CLI inside Codex containers.

New Features:
- Introduce a Codex environment setup hook that installs core development tooling (Go, shellcheck, shfmt, actionlint, Node.js/Prettier) into user-local paths with idempotent behavior.
- Add a Codex GitHub CLI setup hook that auto-installs the gh binary to a local bin directory and wires it into PATH for Codex sessions.
- Provide helper lint-shell and lint-docs scripts for consistent shell and documentation linting across the project.

Enhancements:
- Persist PATH updates for installed tools via CODEX_ENV_FILE when available to ensure subsequent Codex sessions reuse the configured environment.