### PR TITLE
feat: install podman and alias docker in setup hook (Closes #72)

### DIFF
--- a/.codex/hooks/podman-setup.sh
+++ b/.codex/hooks/podman-setup.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+sudo apt-get update
+sudo apt-get install -y podman
+sudo ln -sf "$(command -v podman)" /usr/local/bin/docker
+
+mkdir -p "${repo_root}/certs"
+cp /usr/local/share/ca-certificates/envoy-mitmproxy-ca-cert.crt \
+  "${repo_root}/certs/egress-proxy.crt"
+
+cd "${repo_root}"
+sudo podman build --isolation=chroot -f Dockerfile.podman .

--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,5 @@ out/
 # Claude Code
 .claude/settings.local.json
 
+# Podman build artifacts
+certs/

--- a/Dockerfile.podman
+++ b/Dockerfile.podman
@@ -1,0 +1,75 @@
+# Shell Development Environment (Podman build)
+# This Dockerfile mirrors Dockerfile with a host CA cert copy for proxy support.
+
+FROM ubuntu:22.04
+
+# Avoid interactive prompts during package installation
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install shellcheck and dependencies
+RUN apt-get update && \
+    apt-get install -y \
+    shellcheck \
+    wget \
+    git \
+    bats \
+    curl \
+    nodejs \
+    npm \
+    && rm -rf /var/lib/apt/lists/*
+
+# ホストのCA証明書をコピー（Codex環境のプロキシ対応）
+COPY certs/egress-proxy.crt /usr/local/share/ca-certificates/egress-proxy.crt
+RUN update-ca-certificates
+
+# Install Go 1.23 (required for shfmt v3.12.0)
+RUN wget -O /tmp/go.tar.gz https://go.dev/dl/go1.23.5.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzf /tmp/go.tar.gz && \
+    rm /tmp/go.tar.gz
+ENV PATH="/usr/local/go/bin:/root/go/bin:${PATH}"
+
+# Install shfmt via go install (secure and maintainable)
+RUN go install mvdan.cc/sh/v3/cmd/shfmt@v3.12.0 && \
+    mv /root/go/bin/shfmt /usr/local/bin/shfmt
+
+# Install actionlint via go install (secure and maintainable)
+RUN go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.5 && \
+    mv /root/go/bin/actionlint /usr/local/bin/actionlint
+
+# Install Prettier
+RUN npm install -g prettier@3.4.2
+
+# Set working directory
+WORKDIR /workspace
+
+# Create a script to run both linters
+RUN echo '#!/bin/bash\n\
+set -e\n\
+echo "Running shellcheck..."\n\
+find . -name "*.sh" -type f -print0 | xargs -0 shellcheck --severity=warning\n\
+echo ""\n\
+echo "Running shfmt..."\n\
+find . -name "*.sh" -not -name "*.bats" -type f -print0 | xargs -0 shfmt -i 2 -d\n\
+echo ""\n\
+echo "All linting checks passed!"\n\
+' > /usr/local/bin/lint-shell && \
+    chmod +x /usr/local/bin/lint-shell
+
+# Create a script to run document formatting checks
+RUN echo '#!/bin/bash\n\
+set -e\n\
+echo \"Running Prettier (Markdown)...\"\n\
+prettier --check \"README.md\" \"AGENTS.md\" \"CLAUDE.md\" \"docs/**/*.md\" \".github/**/*.md\"\n\
+echo \"\"\n\
+echo \"Running Prettier (YAML)...\"\n\
+prettier --check \"compose.yml\" \"codecov.yml\" \".github/**/*.{yml,yaml}\"\n\
+echo \"\"\n\
+echo \"Running Prettier (JSON)...\"\n\
+prettier --check \".github/**/*.json\"\n\
+echo \"\"\n\
+echo \"All document linting checks passed!\"\n\
+' > /usr/local/bin/lint-docs && \
+    chmod +x /usr/local/bin/lint-docs
+
+# Default command
+CMD ["lint-shell"]


### PR DESCRIPTION
### Motivation

- Support Podman-based image builds in environments where Docker is unavailable and where TLS egress/proxy interception requires staging a host CA into the build context.
- Make the `docker` CLI usable in those environments by mapping it to `podman` so existing Docker workflows continue to work.

### Description

- Install Podman in the setup hook by running `apt-get` inside `.codex/hooks/podman-setup.sh` and create a symlink so `/usr/local/bin/docker` points to the `podman` binary.
- Ensure the hook copies the host proxy CA into the repo as `certs/egress-proxy.crt` and invokes `podman build --isolation=chroot -f Dockerfile.podman .` to build the image.
- Add `Dockerfile.podman` to mirror the main image build and include copying the staged CA into `/usr/local/share/ca-certificates/` during the image build, and update `.gitignore` to ignore the `certs/` directory.
- Closes #72.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975e95cd6d0832d9cd1c4cb1fbc0753)

## Summary by Sourcery

Add Podman-based image build support and map the docker CLI to Podman in the setup hook.

New Features:
- Introduce a setup hook script to install Podman and alias the docker command to the Podman binary.
- Add a Podman-specific Dockerfile to build the project image in environments without Docker.

Enhancements:
- Stage the host proxy CA certificate into the repository for use during image builds and configure the image build to import it into the container trust store.
- Update gitignore to exclude the generated certificates directory from version control.