### PR TITLE
chore: add codex setup script

### DIFF
--- a/.codex/hooks/codex-setup.sh
+++ b/.codex/hooks/codex-setup.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Codex setup script
+# This script provisions Codex-friendly tooling by chaining the
+# gh, environment, and skills setup hooks.
+
+set -euo pipefail
+
+LOG_PREFIX="[codex-setup]"
+
+log() {
+  echo "$LOG_PREFIX $1" >&2
+}
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+
+log "Starting Codex setup..."
+
+log "1/3 Running gh CLI setup..."
+bash "$REPO_ROOT/.codex/hooks/gh-setup.sh"
+
+log "2/3 Running environment setup..."
+bash "$REPO_ROOT/.codex/hooks/env-setup.sh"
+
+log "3/3 Syncing skills directory..."
+bash "$REPO_ROOT/.claude/hooks/skills-setup.sh"
+
+log "Codex setup completed successfully."


### PR DESCRIPTION
### Motivation
- Provide a simple, Codex-friendly entrypoint that runs the repository's Codex setup hooks in order with consistent logging and repo-root resolution.

### Description
- Add executable `/.codex/hooks/codex-setup.sh` which enables `set -euo pipefail`, defines a `log` helper, resolves `REPO_ROOT`, and sequentially invokes `bash .codex/hooks/gh-setup.sh`, `bash .codex/hooks/env-setup.sh`, and `bash .claude/hooks/skills-setup.sh`.

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a15c82cb0832db558214af6bfc795)

## Summary by Sourcery

Chores:
- Introduce a Codex setup shell script that runs gh, environment, and skills setup hooks with consistent logging and repo-root resolution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added a new unified setup orchestration process that sequences initialization steps in a single command, improving setup reliability with enhanced error handling and detailed progress logging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->