### PR TITLE
chore: switch GitHub Actions runners to ubuntu-latest

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -22,7 +22,7 @@ on:
 jobs:
   actionlint:
     name: Lint GitHub Actions
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   add-to-project:
     name: Add issue to project
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ on:
 jobs:
   Lint:
     name: ShellCheck Lint
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       contents: read
 
@@ -46,7 +46,7 @@ jobs:
           find . -name "*.sh" -type f -print0 | xargs -0 shfmt -d -i 2
 
   Test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/doc-lint.yml
+++ b/.github/workflows/doc-lint.yml
@@ -22,7 +22,7 @@ on:
 jobs:
   markdown:
     name: Markdown format check
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
@@ -43,7 +43,7 @@ jobs:
 
   yaml:
     name: YAML format check
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
@@ -64,7 +64,7 @@ jobs:
 
   json:
     name: JSON format check
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
### Motivation

- Standardize GitHub Actions runner images to `ubuntu-latest` across workflows to avoid pinning to a specific Ubuntu minor version and keep runner updates consistent.

### Description

- Replace `runs-on: ubuntu-22.04` with `runs-on: ubuntu-latest` in `./github/workflows/ci.yml` for the `Lint` and `Test` jobs.
- Replace `runs-on: ubuntu-22.04` with `runs-on: ubuntu-latest` in `./github/workflows/actionlint.yml` for the `actionlint` job.
- Replace `runs-on: ubuntu-22.04` with `runs-on: ubuntu-latest` in `./github/workflows/doc-lint.yml` for the `markdown`, `yaml`, and `json` jobs.
- Replace `runs-on: ubuntu-22.04` with `runs-on: ubuntu-latest` in `./github/workflows/add-to-project.yml` for the `add-to-project` job.

### Testing

- No automated tests were executed for this change; the modifications are limited to GitHub Actions workflow configuration and should be validated by observing workflow runs on the repository after merging.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a198118b4832d8a8248fc45a6f946)

## Summary by Sourcery

CI:
- Update all CI-related GitHub Actions workflows to run on ubuntu-latest runners for linting, testing, documentation linting, and project automation jobs.