### PR TITLE
feat: add copilot instructions (Closes #91)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,21 @@
+# Repository Instructions for GitHub Copilot
+
+## Project context
+
+- This repository is a template for new development projects. It provides default GitHub workflows, issue/PR templates, rulesets, automation scripts, and documentation. Keep changes aligned with the goal of being reusable and easy to customize for downstream projects.
+- The canonical skill documentation lives under `.github/skills/`. Use those files as the source of truth for contribution conventions and review practices.
+- Documentation files should remain well-formatted (Prettier is used for Markdown/YAML/JSON where applicable).
+
+## References to skills
+
+Follow the guidance in the following skills as needed:
+
+- [Git commit granularity](./skills/git-commit/SKILL.md)
+- [Commit message conventions](./skills/commit-message/SKILL.md)
+- [Pull request guidelines](./skills/pull-request/SKILL.md)
+- [Code review checklist](./skills/code-review/SKILL.md)
+- [Self-review checklist](./skills/self-review/SKILL.md)
+- [Security review](./skills/reviewing-security/SKILL.md)
+- [Test-driven development](./skills/test-driven-development/SKILL.md)
+- [Design planning](./skills/design-plan/SKILL.md)
+- [GitHub issue creation](./skills/github-issue/SKILL.md)


### PR DESCRIPTION
### Motivation

- Add repository-level GitHub Copilot instructions to provide project context and reference existing skills, addressing Issue `#91`.

### Description

- Create `.github/copilot-instructions.md` containing concise project context and links to the canonical skill documents under `./skills/` (commit message, PR guidelines, code review, security review, TDD, design plan, and issue creation).

### Testing

- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d86765020832d8f7b9fb50dd864d1)

## Summary by Sourcery

Documentation:
- Document project context and contribution conventions for AI assistants in `.github/copilot-instructions.md`, linking to existing skill guides under `.github/skills/` as the source of truth.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added repository development guidelines and standards documentation for project configuration and best practices.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->