### PR TITLE
chore: use scripts for copilot setup steps

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -10,19 +10,19 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Build Docker environment
+      - name: Setup development tools
         run: |
-          echo "Building Docker Compose environment..."
-          docker compose build
+          echo "Installing shell linting tools..."
+          bash scripts/install-tools.sh
 
       - name: Verify environment setup
         run: |
           echo "Verifying shell linting tools..."
-          docker compose run --rm shell-dev shellcheck --version
-          docker compose run --rm shell-dev shfmt --version
-          docker compose run --rm shell-dev actionlint --version
+          shellcheck --version
+          shfmt --version
+          actionlint --version
 
       - name: Run shell script linting
         run: |
           echo "Running shell linting checks..."
-          docker compose run --rm shell-dev lint-shell
+          bash scripts/lint-shell.sh


### PR DESCRIPTION
### Motivation
- Remove the Docker Compose dependency from the Copilot setup workflow and centralize tool installation to the shared scripts to reduce CI runtime and simplify setup.

### Description
- Updated `.github/workflows/copilot-setup-steps.yml` to run `bash scripts/install-tools.sh`, verify tools with `shellcheck --version`, `shfmt --version`, and `actionlint --version`, and run `bash scripts/lint-shell.sh`, removing `docker compose build/run` usage; Close #107.

### Testing
- No automated tests were run for this change; the workflow file was inspected and the change committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69871099d158832d850bd78f173687f9)

## Summary by Sourcery

CI:
- Simplify the Copilot setup workflow by installing shell linting tools via scripts/install-tools.sh and running linting via scripts/lint-shell.sh, removing the Docker Compose dependency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized development workflow setup and linting processes for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->