### PR TITLE
fix: enforce local prettier usage

### DIFF
--- a/.githooks/run-checks.sh
+++ b/.githooks/run-checks.sh
@@ -53,6 +53,10 @@ fi
 # Use the same commands as CI (doc-lint.yml)
 if "$has_docs"; then
   log "Running document checks..."
+  if [ ! -x "$REPO_ROOT/node_modules/.bin/prettier" ]; then
+    log "Prettier is not installed. Run 'npm ci' to install dependencies."
+    exit 1
+  fi
   npm run format:check
   checked=true
 fi

--- a/package.json
+++ b/package.json
@@ -3,11 +3,11 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "format": "prettier --write \"README.md\" \"AGENTS.md\" \"CLAUDE.md\" \"docs/**/*.md\" \".github/**/*.md\" \"compose.yml\" \"codecov.yml\" \".github/**/*.{yml,yaml}\" \".github/**/*.json\"",
-    "format:check": "prettier --check \"README.md\" \"AGENTS.md\" \"CLAUDE.md\" \"docs/**/*.md\" \".github/**/*.md\" \"compose.yml\" \"codecov.yml\" \".github/**/*.{yml,yaml}\" \".github/**/*.json\"",
-    "format:md": "prettier --check \"README.md\" \"AGENTS.md\" \"CLAUDE.md\" \"docs/**/*.md\" \".github/**/*.md\"",
-    "format:yaml": "prettier --check \"compose.yml\" \"codecov.yml\" \".github/**/*.{yml,yaml}\"",
-    "format:json": "prettier --check \".github/**/*.json\""
+    "format": "npx --no-install prettier --write \"README.md\" \"AGENTS.md\" \"CLAUDE.md\" \"docs/**/*.md\" \".github/**/*.md\" \"compose.yml\" \"codecov.yml\" \".github/**/*.{yml,yaml}\" \".github/**/*.json\"",
+    "format:check": "npx --no-install prettier --check \"README.md\" \"AGENTS.md\" \"CLAUDE.md\" \"docs/**/*.md\" \".github/**/*.md\" \"compose.yml\" \"codecov.yml\" \".github/**/*.{yml,yaml}\" \".github/**/*.json\"",
+    "format:md": "npx --no-install prettier --check \"README.md\" \"AGENTS.md\" \"CLAUDE.md\" \"docs/**/*.md\" \".github/**/*.md\"",
+    "format:yaml": "npx --no-install prettier --check \"compose.yml\" \"codecov.yml\" \".github/**/*.{yml,yaml}\"",
+    "format:json": "npx --no-install prettier --check \".github/**/*.json\""
   },
   "devDependencies": {
     "prettier": "3.4.2"

--- a/scripts/lint-docs.sh
+++ b/scripts/lint-docs.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 declare -a markdown_files=()
 declare -a yaml_files=()
 declare -a json_files=()
+prettier_cmd=(npx --no-install prettier)
 
 matches_markdown() {
   local file="$1"
@@ -51,19 +52,19 @@ fi
 
 if [ "${#markdown_files[@]}" -gt 0 ]; then
   echo "Running Prettier (Markdown)..."
-  prettier --check "${markdown_files[@]}"
+  "${prettier_cmd[@]}" --check "${markdown_files[@]}"
   echo ""
 fi
 
 if [ "${#yaml_files[@]}" -gt 0 ]; then
   echo "Running Prettier (YAML)..."
-  prettier --check "${yaml_files[@]}"
+  "${prettier_cmd[@]}" --check "${yaml_files[@]}"
   echo ""
 fi
 
 if [ "${#json_files[@]}" -gt 0 ]; then
   echo "Running Prettier (JSON)..."
-  prettier --check "${json_files[@]}"
+  "${prettier_cmd[@]}" --check "${json_files[@]}"
   echo ""
 fi
 


### PR DESCRIPTION
### Motivation

- Prevent inconsistent formatting caused by a globally-installed Prettier being used locally instead of the project `devDependencies` version.
- Ensure git hooks and document linting use the repo-local Prettier and fail fast when dependencies are missing.
- Close #119

### Description

- Change package `scripts` to call Prettier via `npx --no-install` so only the local `node_modules` Prettier is used.
- Update `scripts/lint-docs.sh` to invoke Prettier through a `prettier_cmd=(npx --no-install prettier)` wrapper.
- Add a guard in `.githooks/run-checks.sh` that checks `node_modules/.bin/prettier` and prints an instructive message and exits if Prettier is not installed.

### Testing

- Ran `npm ci` to install dependencies and then ran `npm run format:check`, which completed with `All matched files use Prettier code style!`.
- Ran shell linting via `scripts/lint-shell.sh`, which passed successfully during pre-commit checks.
- Verified committing the changes triggered the hooks and the document checks passed after installing dependencies.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987528c3c58832dab8eb33daae16cc9)

## Summary by Sourcery

Enforce use of the repo-local Prettier in scripts and git hooks to ensure consistent formatting and clear failures when dependencies are missing.

Enhancements:
- Update npm formatting scripts to invoke Prettier via `npx --no-install` so only the local dependency is used.
- Adjust documentation linting script to route all Prettier checks through a shared `npx --no-install prettier` command wrapper.
- Add a guard in the git run-checks hook to fail with an instructive message when the local Prettier binary is not installed.