### PR TITLE
chore: exclude .github/skills from Prettier formatting

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,5 @@ node_modules
 coverage
 build
 dist
+# Skills are AI agent prompts; keep formatting as-authored.
+.github/skills

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "format": "npx --no-install prettier --write \"README.md\" \"AGENTS.md\" \"CLAUDE.md\" \"docs/**/*.md\" \".github/**/*.md\" \"compose.yml\" \"codecov.yml\" \".github/**/*.{yml,yaml}\" \".github/**/*.json\"",
-    "format:check": "npx --no-install prettier --check \"README.md\" \"AGENTS.md\" \"CLAUDE.md\" \"docs/**/*.md\" \".github/**/*.md\" \"compose.yml\" \"codecov.yml\" \".github/**/*.{yml,yaml}\" \".github/**/*.json\"",
-    "format:md": "npx --no-install prettier --check \"README.md\" \"AGENTS.md\" \"CLAUDE.md\" \"docs/**/*.md\" \".github/**/*.md\"",
+    "format": "npx --no-install prettier --write \"README.md\" \"AGENTS.md\" \"CLAUDE.md\" \"docs/**/*.md\" \".github/**/*.md\" \"!.github/skills/**\" \"compose.yml\" \"codecov.yml\" \".github/**/*.{yml,yaml}\" \".github/**/*.json\"",
+    "format:check": "npx --no-install prettier --check \"README.md\" \"AGENTS.md\" \"CLAUDE.md\" \"docs/**/*.md\" \".github/**/*.md\" \"!.github/skills/**\" \"compose.yml\" \"codecov.yml\" \".github/**/*.{yml,yaml}\" \".github/**/*.json\"",
+    "format:md": "npx --no-install prettier --check \"README.md\" \"AGENTS.md\" \"CLAUDE.md\" \"docs/**/*.md\" \".github/**/*.md\" \"!.github/skills/**\"",
     "format:yaml": "npx --no-install prettier --check \"compose.yml\" \"codecov.yml\" \".github/**/*.{yml,yaml}\"",
     "format:json": "npx --no-install prettier --check \".github/**/*.json\""
   },


### PR DESCRIPTION
### Motivation

- Prettier was reformatting AI skill files under `.github/skills`, removing intentional blank lines and causing repeated `format:check` failures for SKILL files.
- The change preserves prompt-oriented Markdown formatting in skill files while keeping repository formatting checks consistent.

### Description

- Add `.github/skills` to `.prettierignore` to exclude skill files from automatic Prettier formatting.
- Update `package.json` `format`, `format:check`, and `format:md` scripts to explicitly exclude `.github/skills/**` from Prettier targets.
- No functional code changes; only formatting/configuration updates.
- Close #122

### Testing

- Ran `npm run format:check` and the command completed with "All matched files use Prettier code style!" indicating the formatting checks passed.
- Pre-commit document checks ran during commit and passed after installing dev dependencies (`npm ci`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69882832dfc4832dbd79f92028d53698)

## Summary by Sourcery

Exclude AI skill configuration files from automated Prettier formatting to preserve their intentional Markdown layout while keeping repository formatting checks intact.

Build:
- Update Prettier CLI script targets in package.json to omit files under .github/skills from format, format:check, and format:md commands.

Chores:
- Add .github/skills to Prettier ignore configuration so skill files are not auto-reformatted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code formatting configuration to exclude AI-generated content directories from formatting processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->