### PR TITLE
feat: add git remote remove origin step to codex-setup.sh

### DIFF
--- a/.codex/hooks/codex-setup.sh
+++ b/.codex/hooks/codex-setup.sh
@@ -15,8 +15,12 @@ REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
 
 log "Starting Codex setup..."
 
-log "1/5 Removing git remote origin..."
-git -C "$REPO_ROOT" remote remove origin 2>/dev/null || true
+if [ "${CODEX_REMOTE:-}" = "true" ]; then
+  log "1/5 Removing git remote origin..."
+  git -C "$REPO_ROOT" remote remove origin 2>/dev/null || true
+else
+  log "1/5 Skipping git remote removal (not a remote session)"
+fi
 
 log "2/5 Running gh CLI setup..."
 bash "$REPO_ROOT/.codex/hooks/gh-setup.sh"

--- a/tests/codex-setup.bats
+++ b/tests/codex-setup.bats
@@ -6,9 +6,28 @@ REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
 SCRIPT="$REPO_ROOT/.codex/hooks/codex-setup.sh"
 
 setup() {
-  # Create a temporary workspace that looks like a git repo with a remote
+  # Create a temporary workspace that mimics the repo directory structure
   export WORK_DIR
   WORK_DIR="$(mktemp -d)"
+
+  mkdir -p "$WORK_DIR/.codex/hooks"
+  mkdir -p "$WORK_DIR/.claude/hooks"
+  mkdir -p "$WORK_DIR/scripts"
+
+  # Copy the actual script under test
+  cp "$SCRIPT" "$WORK_DIR/.codex/hooks/codex-setup.sh"
+
+  # Create no-op stubs for the other hooks so codex-setup.sh can run end-to-end
+  for stub in \
+    "$WORK_DIR/.codex/hooks/gh-setup.sh" \
+    "$WORK_DIR/.codex/hooks/env-setup.sh" \
+    "$WORK_DIR/.claude/hooks/skills-setup.sh" \
+    "$WORK_DIR/scripts/setup-git-hooks.sh"; do
+    printf '#!/bin/bash\nexit 0\n' >"$stub"
+    chmod +x "$stub"
+  done
+
+  # Initialise a git repo with an origin remote
   git -C "$WORK_DIR" init --quiet
   git -C "$WORK_DIR" remote add origin https://example.com/repo.git
 }
@@ -17,36 +36,47 @@ teardown() {
   rm -rf "$WORK_DIR"
 }
 
-@test "codex-setup.sh contains git remote remove step" {
-  grep -q 'git.*remote.*remove\|git.*remote.*rm' "$SCRIPT"
+@test "codex-setup.sh contains CODEX_REMOTE-guarded git remote remove step" {
+  grep -q 'CODEX_REMOTE' "$SCRIPT"
+  grep -q 'git -C "\$REPO_ROOT" remote remove origin' "$SCRIPT"
 }
 
-@test "git remote remove origin is idempotent (no error when remote absent)" {
-  # Remove remote first so it doesn't exist
-  git -C "$WORK_DIR" remote remove origin
-
-  # Source just the remote-removal portion — simulate the logic
-  # that codex-setup.sh should have
-  run bash -c "
-    cd '$WORK_DIR'
-    git remote remove origin 2>/dev/null || true
-  "
-  [ "$status" -eq 0 ]
-}
-
-@test "git remote remove origin actually removes the remote" {
+@test "codex-setup.sh removes origin when CODEX_REMOTE=true" {
   # Verify remote exists before
   run git -C "$WORK_DIR" remote
   [[ "$output" == *"origin"* ]]
 
-  # Execute the remove logic that should be in codex-setup.sh
-  run bash -c "
-    cd '$WORK_DIR'
-    git remote remove origin 2>/dev/null || true
-  "
+  # Run the actual script with CODEX_REMOTE=true
+  export CODEX_REMOTE=true
+  run bash "$WORK_DIR/.codex/hooks/codex-setup.sh"
   [ "$status" -eq 0 ]
 
   # Verify remote is gone
   run git -C "$WORK_DIR" remote
   [[ "$output" != *"origin"* ]]
+}
+
+@test "codex-setup.sh preserves origin when CODEX_REMOTE is not set" {
+  # Verify remote exists before
+  run git -C "$WORK_DIR" remote
+  [[ "$output" == *"origin"* ]]
+
+  # Run the actual script without CODEX_REMOTE
+  unset CODEX_REMOTE
+  run bash "$WORK_DIR/.codex/hooks/codex-setup.sh"
+  [ "$status" -eq 0 ]
+
+  # Verify remote still exists
+  run git -C "$WORK_DIR" remote
+  [[ "$output" == *"origin"* ]]
+}
+
+@test "codex-setup.sh is idempotent when origin is already absent" {
+  # Remove remote first
+  git -C "$WORK_DIR" remote remove origin
+
+  # Run the actual script – should not error
+  export CODEX_REMOTE=true
+  run bash "$WORK_DIR/.codex/hooks/codex-setup.sh"
+  [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
## Description

Codex環境ではリポジトリClone後にgit remoteが残存し、後続のセットアップフック（gh CLI等）が不安定になる場合があります。`codex-setup.sh` の最初のステップとして `git remote remove origin` を追加し、確実な動作を保証します。

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Related Issues

Closes #124

## Changes Made

- `.codex/hooks/codex-setup.sh` にgit remote削除ステップを追加
  - セットアップの最初のステップ（1/5）として `git -C "$REPO_ROOT" remote remove origin` を実行
  - `2>/dev/null || true` により冪等性を確保（remoteが存在しない場合でもエラーにならない）
  - 既存の4ステップを2/5〜5/5に繰り下げ

- `tests/codex-setup.bats` を新規追加（テスト3件）
  - スクリプトに `git remote remove` のステップが含まれることの検証
  - remoteが存在しない場合の冪等性の検証
  - remoteが実際に削除されることの検証

## Testing

- [x] テストを追加/更新しました
- [x] 既存のテストがすべて通過します
- [x] 手動で動作確認しました

## Checklist

- [x] コードはプロジェクトのスタイルガイドに従っています
- [x] 自己レビューを実施しました
- [x] コメントを適切に追加しました（特に複雑な部分）
- [x] 関連するドキュメントを更新しました
- [x] 変更によって新しい警告は発生していません
- [x] テストを追加/更新しました
- [x] すべてのテストが通過します

## Additional Notes

- shellcheck / shfmt 通過済み
- pre-commit / pre-push hook 通過済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure Codex setup removes any existing git remote origin before running subsequent setup steps to improve reliability.

New Features:
- Add an initial Codex setup step that removes the git remote origin from the repository in an idempotent way.

Tests:
- Introduce Bats tests to verify the presence, idempotency, and effectiveness of the git remote origin removal logic in the Codex setup script.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Setup initialization now includes a git remote origin removal step that executes before other configuration tasks.

* **Tests**
  * New test suite validates git remote removal functionality, ensuring idempotent behavior and confirming proper remote cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->