### PR TITLE
feat: add react-to-review skill

### DIFF
--- a/.github/skills/react-to-review/SKILL.md
+++ b/.github/skills/react-to-review/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: react-to-review
+description: "PRレビューコメント対応スキル。レビューコメントを取得し、妥当な指摘を修正したうえで各コメントへ対応結果とコミットSHAを返信する。Use when: レビューコメント対応、レビュー指摘の修正、コメント返信の自動化を依頼された時。"
+---
+
+# react-to-review
+
+PRのレビューコメントに対応するためのスキルです。
+
+レビューコメントを取得し、妥当な指摘を修正したうえで、
+各コメントに「何を対応したか」と「対応コミットSHA」を返信します。
+
+## このスキルの目的
+
+- レビュー対応漏れを防ぐ
+- どのコメントにどのコミットで対応したかを明確化する
+- レビュアーの再確認コストを下げる
+
+## 前提条件
+
+- 対象PR番号が分かっていること
+- `gh` コマンドが利用可能で認証済みであること
+- 修正作業用ブランチにチェックアウト済みであること
+
+## 実施手順
+
+### 1. 対象PRのレビューコメントを取得
+
+```bash
+# owner/repo は環境に合わせて置き換える
+REPO="owner/repo"
+PR_NUMBER="123"
+
+gh api \
+  "repos/${REPO}/pulls/${PR_NUMBER}/comments" \
+  --jq '.[] | {id: .id, path: .path, line: .line, user: .user.login, body: .body}'
+```
+
+必要に応じて未対応コメントだけを抽出します。
+
+```bash
+gh api \
+  "repos/${REPO}/pulls/${PR_NUMBER}/comments" \
+  --jq '.[] | select(.in_reply_to_id == null) | {id: .id, body: .body}'
+```
+
+### 2. コメントを分類して対応方針を決める
+
+各コメントを以下のどちらかに分類します。
+
+- **対応する**: バグ、仕様逸脱、可読性低下など妥当な指摘
+- **対応しない**: 要件外、誤解、既存制約により対応不能
+
+> 対応しない場合も、理由を返信して会話を閉じる。
+
+### 3. 妥当な指摘を修正してテスト
+
+指摘ごとに修正を行い、関連テストや静的チェックを実行します。
+
+```bash
+# 例: 変更確認
+
+git diff
+
+# 例: プロジェクトに応じたテスト
+npm test
+```
+
+### 4. コミットを作成
+
+Conventional Commitsでコミットします。
+
+```bash
+git add <files>
+git commit -m "fix: address review comments in <scope>"
+```
+
+対応コミットSHAを取得します。
+
+```bash
+COMMIT_SHA=$(git rev-parse --short HEAD)
+echo "$COMMIT_SHA"
+```
+
+### 5. 各レビューコメントに返信
+
+`/pulls/comments/{comment_id}/replies` エンドポイントで返信します。
+
+```bash
+COMMENT_ID="456789"
+
+# 対応した場合
+
+gh api \
+  --method POST \
+  "repos/${REPO}/pulls/comments/${COMMENT_ID}/replies" \
+  -f body="対応しました。Fixed in ${COMMIT_SHA}"
+
+# 対応しない場合（例）
+
+gh api \
+  --method POST \
+  "repos/${REPO}/pulls/comments/${COMMENT_ID}/replies" \
+  -f body="確認しました。今回は要件範囲外のため対応を見送ります。"
+```
+
+## 返信テンプレート
+
+### 対応した場合
+
+```markdown
+対応しました。Fixed in <commit-sha>
+```
+
+### 追加説明が必要な場合
+
+```markdown
+対応しました。<対応内容を1-2文で説明>。
+Fixed in <commit-sha>
+```
+
+### 対応しない場合
+
+```markdown
+確認しました。<対応しない理由>のため今回は見送ります。
+必要であれば別Issueで対応します。
+```
+
+## 複数コメントを1コミットで対応する場合
+
+1つのコミットで複数コメントを解消した場合でも、
+**各コメントに個別返信**して同じコミットSHAを明記します。
+
+## 実行例
+
+```bash
+REPO="yellow-seed/template"
+PR_NUMBER="42"
+COMMIT_SHA=$(git rev-parse --short HEAD)
+
+# コメントID 1001, 1002 に返信
+for COMMENT_ID in 1001 1002; do
+  gh api --method POST \
+    "repos/${REPO}/pulls/comments/${COMMENT_ID}/replies" \
+    -f body="対応しました。Fixed in ${COMMIT_SHA}"
+done
+```
+
+## 他スキルとの連携
+
+- `code-review`: レビュー観点を再確認する
+- `self-review`: 修正後の差分を自己点検する
+- `git-commit`: コミット粒度を適切に保つ
+- `commit-message`: Conventional Commitsに沿って記述する
+- `pull-request`: PR本文の更新や最終チェックを行う


### PR DESCRIPTION
### Motivation

- レビューコメントに対して修正コミットの参照付きでGitHub上に返信する機能がなかったため、PRレビュー対応の工数削減と対応の可視化を目的に新規スキルを追加します（Issue #127 要求）。

### Description

- 新規ファイル ` .github/skills/react-to-review/SKILL.md` を追加し、レビューコメント取得 → 妥当性判断 → 修正 → コミット → コメント返信 の一連フローと運用ルールを定義しました。 
- `gh api` を使ったコメント取得と `/pulls/comments/{comment_id}/replies` での返信例や、返信テンプレート（対応済み: コミットSHA付き、補足説明、対応見送り）を明記しました。 
- PR本文には `Close #127` を含めて Issue 127 と連携するようにしています。 

### Testing

- `npm ci` を実行して依存をインストールしました（成功）。
- `npm run format:check` と pre-commit のドキュメントチェック（Prettier）を実行し、`git commit` 時のフック含め最終的にフォーマットチェックは全て通過しました。 
- 変更ファイルは `git commit` によりコミットされ、ドキュメント形式チェックを通過しています。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f3d36eb18832dbd5d5910522bdeee)

## Summary by Sourcery

Add a new GitHub skill for systematically handling PR review comments by applying fixes and replying with the corresponding commit SHA.

New Features:
- Document a react-to-review skill that guides fetching PR review comments, deciding response policy, applying fixes, committing changes, and replying with commit SHAs via gh api.

Documentation:
- Add SKILL documentation describing the workflow, templates, and usage rules for automating responses to PR review comments with GitHub CLI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guide for the PR review-comment handling workflow, including step-by-step instructions for addressing review comments, running tests, committing changes, and automatically posting replies through the GitHub API. Guide also covers handling multiple comments and integration patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->