### PR TITLE
feat: scope GH token usage to gh command execution

### DIFF
--- a/.claude/hooks/gh-setup.sh
+++ b/.claude/hooks/gh-setup.sh
@@ -3,6 +3,19 @@ set -e
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
+if [ -z "${GH_SETUP_TOKEN:-}" ]; then
+  if [ -n "${CLAUDE_GH_AUTH:-}" ]; then
+    export GH_SETUP_TOKEN="${CLAUDE_GH_AUTH}"
+  elif [ -n "${GH_TOKEN:-}" ]; then
+    export GH_SETUP_TOKEN="${GH_TOKEN}"
+  elif [ -n "${GITHUB_TOKEN:-}" ]; then
+    export GH_SETUP_TOKEN="${GITHUB_TOKEN}"
+  fi
+fi
+
+unset GH_TOKEN
+unset GITHUB_TOKEN
+
 export REMOTE_ENV_VAR="CLAUDE_CODE_REMOTE"
 export ENV_FILE="${CLAUDE_ENV_FILE:-}"
 

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,8 @@
+# Codex local configuration for this repository.
+# Keep GitHub tokens out of the default shell environment and only inject
+# them when running gh commands.
+
+[shell_environment_policy]
+inherit = "core"
+ignore_default_excludes = false
+exclude = ["GH_TOKEN", "GITHUB_TOKEN"]

--- a/.codex/hooks/gh-setup.sh
+++ b/.codex/hooks/gh-setup.sh
@@ -3,6 +3,20 @@ set -e
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
+# Keep tokens out of inherited process environments and inject only for gh commands.
+if [ -z "${GH_SETUP_TOKEN:-}" ]; then
+  if [ -n "${CODEX_GH_AUTH:-}" ]; then
+    export GH_SETUP_TOKEN="${CODEX_GH_AUTH}"
+  elif [ -n "${GH_TOKEN:-}" ]; then
+    export GH_SETUP_TOKEN="${GH_TOKEN}"
+  elif [ -n "${GITHUB_TOKEN:-}" ]; then
+    export GH_SETUP_TOKEN="${GITHUB_TOKEN}"
+  fi
+fi
+
+unset GH_TOKEN
+unset GITHUB_TOKEN
+
 export REMOTE_ENV_VAR="CODEX_REMOTE"
 export ENV_FILE="${CODEX_ENV_FILE:-}"
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,21 @@ Claude Code on the Web などのリモート環境で GitHub CLI (`gh`) コマ�
 bash .claude/hooks/gh-setup.sh
 ```
 
+### リモート環境でのトークン管理ポリシー（Codex）
+
+セキュリティのため、Codex では `GH_TOKEN` / `GITHUB_TOKEN` をデフォルトのシェル環境へ継承しない方針です。
+
+- `.codex/config.toml` の `shell_environment_policy` で `GH_TOKEN` / `GITHUB_TOKEN` を除外
+- `gh` を実行するコマンドにだけトークンを注入
+
+例:
+
+```bash
+env GH_TOKEN="$GH_TOKEN" gh issue list -R yellow-seed/template
+# または
+env GH_SETUP_TOKEN="$GH_TOKEN" bash .codex/hooks/gh-setup.sh
+```
+
 ### リモート環境での gh コマンド使用方法
 
 gitのremoteがローカルプロキシを経由している環境では、`gh` コマンドがリポジトリを自動認識できない場合があります。その場合は以下の方法を使用してください：

--- a/tests/gh-setup.bats
+++ b/tests/gh-setup.bats
@@ -1,0 +1,60 @@
+#!/usr/bin/env bats
+
+# Tests for scripts/gh-setup.sh – token scoping for gh commands
+
+REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/gh-setup.sh"
+
+setup() {
+  export WORK_DIR
+  WORK_DIR="$(mktemp -d)"
+  export FAKE_BIN="$WORK_DIR/bin"
+  mkdir -p "$FAKE_BIN"
+
+  cat >"$FAKE_BIN/gh" <<'GH'
+#!/bin/bash
+printf 'GH_TOKEN=%s GITHUB_TOKEN=%s CMD=%s\n' "${GH_TOKEN:-}" "${GITHUB_TOKEN:-}" "$*" >>"${GH_TEST_LOG}"
+if [ "$1" = "--version" ]; then
+  echo 'gh version 2.62.0'
+  exit 0
+fi
+if [ "$1" = "extension" ] && [ "$2" = "list" ]; then
+  echo 'yahsan2/gh-sub-issue'
+  exit 0
+fi
+exit 0
+GH
+  chmod +x "$FAKE_BIN/gh"
+
+  export PATH="$FAKE_BIN:$PATH"
+  export GH_TEST_LOG="$WORK_DIR/gh.log"
+}
+
+teardown() {
+  rm -rf "$WORK_DIR"
+}
+
+@test "gh-setup injects token only when available" {
+  export REMOTE_ENV_VAR="CODEX_REMOTE"
+  export CODEX_REMOTE="true"
+  export GH_TOKEN="secret-token"
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+
+  run rg -n "GH_TOKEN=secret-token GITHUB_TOKEN=secret-token" "$GH_TEST_LOG"
+  [ "$status" -eq 0 ]
+}
+
+@test "gh-setup runs without token" {
+  export REMOTE_ENV_VAR="CODEX_REMOTE"
+  export CODEX_REMOTE="true"
+  unset GH_TOKEN
+  unset GITHUB_TOKEN
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+
+  run rg -n "GH_TOKEN= GITHUB_TOKEN=" "$GH_TEST_LOG"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
### Motivation

- Reduce the security surface by preventing `GH_TOKEN`/`GITHUB_TOKEN` from being inherited by all agent subprocesses and only provide tokens to `gh` invocations, addressing the request in Issue #136.

### Description

- Close #136 and add `.codex/config.toml` with a `shell_environment_policy` that inherits the `core` set and explicitly excludes `GH_TOKEN` and `GITHUB_TOKEN`.
- Update `scripts/gh-setup.sh` to resolve a single auth token source (`GH_SETUP_TOKEN`, `CODEX_GH_AUTH`, `CLAUDE_GH_AUTH`, `GH_TOKEN`, `GITHUB_TOKEN`), `unset` ambient token env vars, and provide a `run_gh` wrapper to inject the token only for `gh` command runs.
- Update `.codex/hooks/gh-setup.sh` and `.claude/hooks/gh-setup.sh` to populate `GH_SETUP_TOKEN` from available sources and clear ambient `GH_TOKEN`/`GITHUB_TOKEN` before delegating to the shared script.
- Document the token management policy and usage examples in `AGENTS.md` and add `tests/gh-setup.bats` to cover token-injected and token-less `gh` execution paths.

### Testing

- Pre-commit automated checks (shellcheck, `shfmt`, and Prettier via `npm run format:check` after `npm ci`) ran and passed during the commit.
- A shell syntax check (`bash -n scripts/gh-setup.sh`) was run and succeeded.
- Attempted to run the Bats suite but `bats` was not available in this environment, so the new `tests/gh-setup.bats` was added but could not be executed here (tooling present in CI should run it).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990f750d2f4832d9e28c44539460ca2)

## Summary by Sourcery

Scope GitHub token usage to GitHub CLI invocations and tighten remote shell token handling.

Enhancements:
- Centralize GitHub token resolution in gh-setup.sh and inject tokens only for gh command execution via a wrapper.
- Adjust Codex and Claude remote gh setup hooks to derive a setup token from available sources while clearing ambient GH_TOKEN/GITHUB_TOKEN.
- Configure Codex shell environment policy to exclude GH_TOKEN and GITHUB_TOKEN from the default inherited environment.

Documentation:
- Document the remote token management policy and usage examples for Codex GitHub CLI usage in AGENTS.md.

Tests:
- Add Bats tests verifying that gh-setup injects tokens for gh commands when available and runs without tokens otherwise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced GitHub token security: tokens are now excluded from the default shell environment and injected only when executing GitHub-related commands.
  * Added support for multiple token sources with automatic fallback resolution.

* **Documentation**
  * Added guidance on remote GitHub token management and best practices for using the `-R` flag for explicit repository specification.

* **Tests**
  * Introduced comprehensive test coverage for token injection and scoping behavior to ensure secure token handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->