### PR TITLE
test: address token precedence review feedback for gh-setup tests

### DIFF
--- a/.claude/hooks/gh-setup.sh
+++ b/.claude/hooks/gh-setup.sh
@@ -3,6 +3,19 @@ set -e
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
+if [ -z "${GH_SETUP_TOKEN:-}" ]; then
+  if [ -n "${CLAUDE_GH_AUTH:-}" ]; then
+    export GH_SETUP_TOKEN="${CLAUDE_GH_AUTH}"
+  elif [ -n "${GH_TOKEN:-}" ]; then
+    export GH_SETUP_TOKEN="${GH_TOKEN}"
+  elif [ -n "${GITHUB_TOKEN:-}" ]; then
+    export GH_SETUP_TOKEN="${GITHUB_TOKEN}"
+  fi
+fi
+
+unset GH_TOKEN
+unset GITHUB_TOKEN
+
 export REMOTE_ENV_VAR="CLAUDE_CODE_REMOTE"
 export ENV_FILE="${CLAUDE_ENV_FILE:-}"
 

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,8 @@
+# Codex local configuration for this repository.
+# Keep GitHub tokens out of the default shell environment and only inject
+# them when running gh commands.
+
+[shell_environment_policy]
+inherit = "core"
+ignore_default_excludes = false
+exclude = ["GH_TOKEN", "GITHUB_TOKEN"]

--- a/.codex/hooks/gh-setup.sh
+++ b/.codex/hooks/gh-setup.sh
@@ -3,6 +3,20 @@ set -e
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
+# Keep tokens out of inherited process environments and inject only for gh commands.
+if [ -z "${GH_SETUP_TOKEN:-}" ]; then
+  if [ -n "${CODEX_GH_AUTH:-}" ]; then
+    export GH_SETUP_TOKEN="${CODEX_GH_AUTH}"
+  elif [ -n "${GH_TOKEN:-}" ]; then
+    export GH_SETUP_TOKEN="${GH_TOKEN}"
+  elif [ -n "${GITHUB_TOKEN:-}" ]; then
+    export GH_SETUP_TOKEN="${GITHUB_TOKEN}"
+  fi
+fi
+
+unset GH_TOKEN
+unset GITHUB_TOKEN
+
 export REMOTE_ENV_VAR="CODEX_REMOTE"
 export ENV_FILE="${CODEX_ENV_FILE:-}"
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,21 @@ Claude Code on the Web などのリモート環境で GitHub CLI (`gh`) コマ�
 bash .claude/hooks/gh-setup.sh
 ```
 
+### リモート環境でのトークン管理ポリシー（Codex）
+
+セキュリティのため、Codex では `GH_TOKEN` / `GITHUB_TOKEN` をデフォルトのシェル環境へ継承しない方針です。
+
+- `.codex/config.toml` の `shell_environment_policy` で `GH_TOKEN` / `GITHUB_TOKEN` を除外
+- `gh` を実行するコマンドにだけトークンを注入
+
+例:
+
+```bash
+env GH_TOKEN="$GH_TOKEN" gh issue list -R yellow-seed/template
+# または
+env GH_SETUP_TOKEN="$GH_TOKEN" bash .codex/hooks/gh-setup.sh
+```
+
 ### リモート環境での gh コマンド使用方法
 
 gitのremoteがローカルプロキシを経由している環境では、`gh` コマンドがリポジトリを自動認識できない場合があります。その場合は以下の方法を使用してください：

--- a/tests/gh-setup.bats
+++ b/tests/gh-setup.bats
@@ -1,0 +1,140 @@
+#!/usr/bin/env bats
+
+# Tests for scripts/gh-setup.sh – token scoping for gh commands
+
+REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/gh-setup.sh"
+
+setup() {
+  export WORK_DIR
+  WORK_DIR="$(mktemp -d)"
+  export FAKE_BIN="$WORK_DIR/bin"
+  mkdir -p "$FAKE_BIN"
+
+  cat >"$FAKE_BIN/gh" <<'GH'
+#!/bin/bash
+printf 'GH_TOKEN=%s GITHUB_TOKEN=%s CMD=%s\n' "${GH_TOKEN:-}" "${GITHUB_TOKEN:-}" "$*" >>"${GH_TEST_LOG}"
+if [ "$1" = "--version" ]; then
+  echo 'gh version 2.62.0'
+  exit 0
+fi
+if [ "$1" = "extension" ] && [ "$2" = "list" ]; then
+  echo 'yahsan2/gh-sub-issue'
+  exit 0
+fi
+exit 0
+GH
+  chmod +x "$FAKE_BIN/gh"
+
+  export PATH="$FAKE_BIN:$PATH"
+  export GH_TEST_LOG="$WORK_DIR/gh.log"
+}
+
+teardown() {
+  rm -rf "$WORK_DIR"
+}
+
+@test "gh-setup injects token only when available" {
+  export REMOTE_ENV_VAR="CODEX_REMOTE"
+  export CODEX_REMOTE="true"
+  export GH_TOKEN="secret-token"
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+
+  run grep -q "GH_TOKEN=secret-token GITHUB_TOKEN=secret-token" "$GH_TEST_LOG"
+  [ "$status" -eq 0 ]
+}
+
+@test "gh-setup prefers GH_SETUP_TOKEN over all token env vars" {
+  export REMOTE_ENV_VAR="CODEX_REMOTE"
+  export CODEX_REMOTE="true"
+  export GH_SETUP_TOKEN="from-gh-setup"
+  export CODEX_GH_AUTH="from-codex"
+  export CLAUDE_GH_AUTH="from-claude"
+  export GH_TOKEN="from-gh-token"
+  export GITHUB_TOKEN="from-github-token"
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+
+  run grep -q "GH_TOKEN=from-gh-setup GITHUB_TOKEN=from-gh-setup" "$GH_TEST_LOG"
+  [ "$status" -eq 0 ]
+}
+
+@test "gh-setup prefers CODEX_GH_AUTH over lower-priority vars" {
+  export REMOTE_ENV_VAR="CODEX_REMOTE"
+  export CODEX_REMOTE="true"
+  unset GH_SETUP_TOKEN
+  export CODEX_GH_AUTH="from-codex"
+  export CLAUDE_GH_AUTH="from-claude"
+  export GH_TOKEN="from-gh-token"
+  export GITHUB_TOKEN="from-github-token"
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+
+  run grep -q "GH_TOKEN=from-codex GITHUB_TOKEN=from-codex" "$GH_TEST_LOG"
+  [ "$status" -eq 0 ]
+}
+
+@test "gh-setup prefers CLAUDE_GH_AUTH over GH_TOKEN and GITHUB_TOKEN" {
+  export REMOTE_ENV_VAR="CODEX_REMOTE"
+  export CODEX_REMOTE="true"
+  unset GH_SETUP_TOKEN
+  unset CODEX_GH_AUTH
+  export CLAUDE_GH_AUTH="from-claude"
+  export GH_TOKEN="from-gh-token"
+  export GITHUB_TOKEN="from-github-token"
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+
+  run grep -q "GH_TOKEN=from-claude GITHUB_TOKEN=from-claude" "$GH_TEST_LOG"
+  [ "$status" -eq 0 ]
+}
+
+@test "gh-setup prefers GH_TOKEN over GITHUB_TOKEN" {
+  export REMOTE_ENV_VAR="CODEX_REMOTE"
+  export CODEX_REMOTE="true"
+  unset GH_SETUP_TOKEN
+  unset CODEX_GH_AUTH
+  unset CLAUDE_GH_AUTH
+  export GH_TOKEN="from-gh-token"
+  export GITHUB_TOKEN="from-github-token"
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+
+  run grep -q "GH_TOKEN=from-gh-token GITHUB_TOKEN=from-gh-token" "$GH_TEST_LOG"
+  [ "$status" -eq 0 ]
+}
+
+@test "gh-setup falls back to GITHUB_TOKEN when it is the only token" {
+  export REMOTE_ENV_VAR="CODEX_REMOTE"
+  export CODEX_REMOTE="true"
+  unset GH_SETUP_TOKEN
+  unset CODEX_GH_AUTH
+  unset CLAUDE_GH_AUTH
+  unset GH_TOKEN
+  export GITHUB_TOKEN="from-github-token"
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+
+  run grep -q "GH_TOKEN=from-github-token GITHUB_TOKEN=from-github-token" "$GH_TEST_LOG"
+  [ "$status" -eq 0 ]
+}
+
+@test "gh-setup runs without token" {
+  export REMOTE_ENV_VAR="CODEX_REMOTE"
+  export CODEX_REMOTE="true"
+  unset GH_TOKEN
+  unset GITHUB_TOKEN
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+
+  run grep -q "GH_TOKEN= GITHUB_TOKEN=" "$GH_TEST_LOG"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
### Motivation

- Improve coverage for `gh` token-resolution behavior and address review comments that requested explicit tests for the configured precedence chain.
- Ensure tokens are not leaked to the inherited shell environment and document the repository token policy for remote agents.

### Description

- Add `resolve_gh_token()` and `run_gh()` helpers to `scripts/gh-setup.sh` and make `gh` invocations use `run_gh` so tokens are injected only per-`gh` command; store the resolved token in `GH_CLI_TOKEN` and unset `GH_TOKEN`/`GITHUB_TOKEN` for safety.
- Update `.claude/hooks/gh-setup.sh` and `.codex/hooks/gh-setup.sh` to map higher-priority auth variables into `GH_SETUP_TOKEN` and to `unset` `GH_TOKEN`/`GITHUB_TOKEN` so tokens are not inherited by unrelated subprocesses.
- Add `.codex/config.toml` with a `shell_environment_policy` that excludes `GH_TOKEN`/`GITHUB_TOKEN` from inherited shells and update `AGENTS.md` to document the token management policy and example usage.
- Add comprehensive tests in `tests/gh-setup.bats` that cover the full precedence chain (`GH_SETUP_TOKEN` > `CODEX_GH_AUTH` > `CLAUDE_GH_AUTH` > `GH_TOKEN` > `GITHUB_TOKEN`) and replace `rg` with `grep` for consistency and reduced external dependency.

### Testing

- Added Bats tests at `tests/gh-setup.bats` which exercise token precedence and no-token scenarios; these tests were committed to the branch.
- Attempted to run `bats tests/gh-setup.bats` in the current environment but `bats` is not installed so the test run could not be executed (failure: `bash: command not found: bats`).
- Pre-commit checks ran as part of the commit and passed, and the changes were committed with message `test: expand gh token precedence coverage`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990fd9918ac832db5466706881744cd)

## Summary by Sourcery

Tighten GitHub CLI token scoping for remote agent environments and add tests and docs around the token precedence chain used by gh-setup.

New Features:
- Introduce centralized token resolution and gh command wrapper in gh-setup to support a defined precedence across multiple token environment variables.
- Add a Codex config file to control which environment variables, including GitHub tokens, are inherited by shells.

Enhancements:
- Update Codex and Claude gh-setup hooks to map higher-priority auth variables into a dedicated GH_SETUP_TOKEN and avoid leaking tokens into child processes.
- Adjust gh-setup logging and extension installation to route all gh invocations through the new wrapper for consistent token injection behavior.

Documentation:
- Document the remote environment token management policy and example usage for Codex in AGENTS.md.

Tests:
- Add Bats tests for gh-setup covering the full token precedence chain, token scoping behavior, and no-token scenarios.