### PR TITLE
fix: preserve installer env across orchestrator steps

### DIFF
--- a/scripts/install-tools.sh
+++ b/scripts/install-tools.sh
@@ -47,7 +47,8 @@ main() {
       continue
     fi
 
-    if ! bash "$ORCHESTRATOR_DIR/installers/${installer}.sh"; then
+    # shellcheck disable=SC1090
+    if ! source "$ORCHESTRATOR_DIR/installers/${installer}.sh"; then
       had_failure=true
       fail "Installer failed: $installer"
       if [ "$STRICT_MODE" != "true" ]; then


### PR DESCRIPTION
### Motivation

- Ensure environment changes (like PATH updates performed by `go.sh`) persist between installer steps so Go-dependent installers (e.g. `shfmt`, `actionlint`) can detect `go` and install correctly.

### Description

- Execute installer scripts with `source` instead of launching a subshell so exported variables remain in the same shell, and add a `# shellcheck disable=SC1090` directive for the dynamic `source` line; Close #150

### Testing

- Ran `bash -n scripts/install-tools.sh scripts/installers/go.sh scripts/installers/shfmt.sh scripts/installers/actionlint.sh` and `bash scripts/lint-shell.sh`, and lint/syntax checks passed after installing required lint binaries.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699dad6ec810832d8ea1dd537369ed12)

## Summary by Sourcery

Bug Fixes:
- Ensure PATH and other exported variables set by installer scripts persist for subsequent installers invoked by the orchestrator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build tool installer process for improved environment handling during installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->