### PR TITLE
fix: propagate detect_arch failures in go and shellcheck installers

### DIFF
--- a/scripts/installers/go.sh
+++ b/scripts/installers/go.sh
@@ -17,7 +17,7 @@ main() {
   fi
 
   if ! detect_arch; then
-    return 0
+    return 1
   fi
 
   log "Installing Go ${GO_VERSION}..."

--- a/scripts/installers/shellcheck.sh
+++ b/scripts/installers/shellcheck.sh
@@ -22,7 +22,7 @@ main() {
   fi
 
   if ! detect_arch; then
-    return 0
+    return 1
   fi
 
   local temp_dir


### PR DESCRIPTION
### Motivation

- `detect_arch` failures were previously treated as success (`return 0`), which masked installation failures on unsupported architectures and allowed the orchestrator to continue erroneously.

### Description

- Change `detect_arch` failure handling to return non-zero in `scripts/installers/go.sh` and `scripts/installers/shellcheck.sh` so failures propagate to the caller; Close #152.

### Testing

- Ran `bash -n scripts/installers/go.sh scripts/installers/shellcheck.sh` and exercised the pre-commit linters via `git commit` (which runs `shellcheck` and `shfmt`), and all automated lint checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699dad8e5268832d932c3a9f95fa6711)

## Summary by Sourcery

Propagate architecture detection failures from the Go and ShellCheck installer scripts so unsupported architectures cause the installers to fail.

Bug Fixes:
- Ensure Go installer exits with a non-zero status when architecture detection fails instead of silently succeeding.
- Ensure ShellCheck installer exits with a non-zero status when architecture detection fails instead of silently succeeding.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed error handling in installer scripts for architecture detection failures. Scripts now properly signal failure when unsupported architectures are encountered, preventing incomplete installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->