### PR TITLE
feat: add qlty check to pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -15,8 +15,8 @@ fi
 cd "$REPO_ROOT"
 
 if command -v qlty >/dev/null 2>&1; then
-  log "Running qlty check --all..."
-  qlty check --all
+  log "Running qlty check --all --verbose..."
+  qlty check --all --verbose
 else
   log "Warning: qlty is not installed. Skipping qlty check."
 fi

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ bash scripts/setup-git-hooks.sh
 
 `pre-commit` フックでは次の処理が実行されます。
 
-- `qlty` がインストールされている場合: `qlty check --all` を実行
+- `qlty` がインストールされている場合: `qlty check --all --verbose` を実行
 - `qlty` が未インストールの場合: 警告を表示してスキップ
 - ステージ済みファイルに対して `.githooks/run-checks.sh` を実行
 


### PR DESCRIPTION
### Motivation

- Issue #163 指示に従い、コミット前にリポジトリ全体の lint を走らせて CI のフィードバックループを短縮し、コミット時点で lint エラーが混入するのを防止するため。 
- `qlty` が未インストールの環境でも既存フックと共存できるよう、チェックをスキップして警告を出す挙動を要求しているため。

### Description

- `.githooks/pre-commit` に `qlty` の存在確認を追加し、存在する場合は `qlty check --all` を実行するようにしました。 
- `qlty` が存在しない場合は警告を出力して `qlty` 実行をスキップし、既存のステージ済みファイル向けチェック (`.githooks/run-checks.sh`) を継続するようにしています。 
- `README.md` に `scripts/setup-git-hooks.sh` の利用手順と `pre-commit` の実行内容（`qlty check --all` の挙動とスキップ時の警告）を追記しました。 
- Close #163

### Testing

- `bash -n .githooks/pre-commit scripts/setup-git-hooks.sh` によるシンタックスチェックを実行し、スクリプト構文は問題ありませんでした。 
- `qlty check --all` を直接実行して挙動を確認しようとしましたが、テスト環境に `qlty` が存在しなかったため実行はスキップされ、スクリプトは警告を出力する挙動を確認しました。 
- pre-commit フックスクリプトを実行して、`qlty` が無い場合に警告を出力して既存のチェックへフォールバックする動作を確認しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0562111b0832d82ec25de675c296b)

## Summary by Sourcery

Add a new pre-commit workflow that runs qlty checks when available and document how to enable Git hooks and what the pre-commit hook runs.

New Features:
- Introduce a pre-commit hook step that runs `qlty check --all --verbose` when qlty is installed and falls back to existing staged-file checks otherwise.

Documentation:
- Document Git hook setup via `scripts/setup-git-hooks.sh` and describe the behavior of the pre-commit hook including qlty execution and its skip behavior when qlty is missing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added setup instructions for Git hooks and GitHub Ruleset configuration, supporting both GitHub Actions and local script methods.

* **Chores**
  * Pre-commit workflow now includes optional quality checks that automatically run when the qlty tool is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->