### PR TITLE
fix: propagate helper installer failures

### DIFF
--- a/scripts/installers/helper-scripts.sh
+++ b/scripts/installers/helper-scripts.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+set -u
+set -o pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+source "$SCRIPT_DIR/_common.sh"
+
+install_helper_script() {
+	local script_name="$1"
+	local source_path="$REPO_ROOT/scripts/${script_name}.sh"
+	local dest_path="$INSTALL_PREFIX/$script_name"
+
+	if [ -x "$dest_path" ]; then
+		log "$script_name already installed"
+		return 0
+	fi
+
+	if [ ! -f "$source_path" ]; then
+		fail "$source_path not found"
+		return 1
+	fi
+
+	if ! cp "$source_path" "$dest_path"; then
+		fail "failed to copy $script_name"
+		return 1
+	fi
+
+	if ! chmod +x "$dest_path"; then
+		fail "failed to mark $script_name as executable"
+		return 1
+	fi
+
+	log "$script_name installed"
+}
+
+main() {
+	local had_error=false
+
+	ensure_path
+
+	install_helper_script "lint-shell" || had_error=true
+	install_helper_script "lint-docs" || had_error=true
+
+	if [ "$had_error" = "true" ]; then
+		return 1
+	fi
+}
+
+main "$@"

--- a/scripts/lint-docs.sh
+++ b/scripts/lint-docs.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -u
+set -o pipefail
+
+exec qlty check --filter prettier "$@"

--- a/scripts/lint-shell.sh
+++ b/scripts/lint-shell.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -u
+set -o pipefail
+
+exec qlty check --filter shellcheck "$@"

--- a/tests/helper-scripts-installer.bats
+++ b/tests/helper-scripts-installer.bats
@@ -1,0 +1,52 @@
+#!/usr/bin/env bats
+
+REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/installers/helper-scripts.sh"
+
+setup() {
+	export WORK_DIR
+	WORK_DIR="$(mktemp -d)"
+
+	mkdir -p "$WORK_DIR/scripts/installers"
+	cp "$REPO_ROOT/scripts/installers/_common.sh" "$WORK_DIR/scripts/installers/_common.sh"
+	cp "$SCRIPT" "$WORK_DIR/scripts/installers/helper-scripts.sh"
+	chmod +x "$WORK_DIR/scripts/installers/helper-scripts.sh"
+
+	export INSTALL_PREFIX="$WORK_DIR/bin"
+	mkdir -p "$INSTALL_PREFIX"
+
+	# Ensure scripts are discoverable from the copied installer's REPO_ROOT.
+	mkdir -p "$WORK_DIR/scripts"
+	cat >"$WORK_DIR/scripts/lint-shell.sh" <<'SHELL'
+#!/bin/bash
+exit 0
+SHELL
+	cat >"$WORK_DIR/scripts/lint-docs.sh" <<'DOCS'
+#!/bin/bash
+exit 0
+DOCS
+	chmod +x "$WORK_DIR/scripts/lint-shell.sh" "$WORK_DIR/scripts/lint-docs.sh"
+}
+
+teardown() {
+	rm -rf "$WORK_DIR"
+}
+
+@test "installer fails when copy step fails" {
+	rm -rf "$INSTALL_PREFIX"
+	ln -s /dev/null "$INSTALL_PREFIX"
+
+	run bash "$WORK_DIR/scripts/installers/helper-scripts.sh"
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"failed to copy lint-shell"* ]]
+}
+
+@test "installer propagates failure when one helper script is missing" {
+	rm -f "$WORK_DIR/scripts/lint-docs.sh"
+
+	run bash "$WORK_DIR/scripts/installers/helper-scripts.sh"
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"lint-docs.sh not found"* ]]
+
+	[ -x "$INSTALL_PREFIX/lint-shell" ]
+}


### PR DESCRIPTION
### Motivation

- Fix error handling in the helper installer so that `cp`/`chmod` failures are detected and reported. 
- Ensure the installer `main` returns non-zero when any helper script installation fails so orchestrators can detect failures.

### Description

- Add `scripts/installers/helper-scripts.sh` that explicitly checks for source presence and fails on `cp` or `chmod` errors, and aggregates per-script failures in `main` so a non-zero status is returned on any error. 
- Add concrete helper wrappers `scripts/lint-shell.sh` and `scripts/lint-docs.sh` as installable targets that delegate to `qlty`. 
- Add regression tests `tests/helper-scripts-installer.bats` covering copy-failure detection and failure propagation. 
- Close #156

### Testing

- Ran a static syntax check with `bash -n scripts/installers/helper-scripts.sh scripts/lint-shell.sh scripts/lint-docs.sh tests/helper-scripts-installer.bats`, which succeeded. 
- Attempted to run `bats tests/helper-scripts-installer.bats`, which failed in this environment because the `bats` command is not installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a05614978c832dbf82a0953d53adbe)

## Summary by Sourcery

Ensure helper script installation failures are detected and cause the installer to exit with a non-zero status.

New Features:
- Add a dedicated helper-scripts installer that installs lint-shell and lint-docs helper commands.
- Introduce lint-shell and lint-docs wrapper scripts that delegate linting to qlty.

Bug Fixes:
- Detect and report failures when copying or chmod-ing helper scripts during installation, and propagate these errors via the installer's exit code.

Tests:
- Add Bats tests to verify that helper script copy failures and missing source scripts cause the installer to fail while still installing remaining valid helpers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added linting utilities for shell and documentation files with strict validation
  * Introduced automated installer for helper scripts with comprehensive error tracking

* **Tests**
  * Added test suite for the helper script installer covering failure scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->