### PR TITLE
fix: avoid precreating apt update stamp

### DIFF
--- a/scripts/install-tools.sh
+++ b/scripts/install-tools.sh
@@ -27,10 +27,12 @@ main() {
 		qlty
 	)
 	local had_failure=false
+	local apt_stamp_dir
 
-	APT_UPDATE_STAMP=$(mktemp)
+	apt_stamp_dir=$(mktemp -d)
+	APT_UPDATE_STAMP="$apt_stamp_dir/apt-update.stamp"
 	export APT_UPDATE_STAMP
-	trap 'rm -f "$APT_UPDATE_STAMP"' EXIT
+	trap 'rm -rf "$apt_stamp_dir"' EXIT
 
 	log "Starting tool installation"
 	ensure_path

--- a/tests/install-tools.bats
+++ b/tests/install-tools.bats
@@ -1,0 +1,35 @@
+#!/usr/bin/env bats
+
+REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+COMMON_SCRIPT="$REPO_ROOT/scripts/installers/_common.sh"
+
+setup() {
+  TEST_DIR="$(mktemp -d)"
+  export PATH="$TEST_DIR:$PATH"
+}
+
+teardown() {
+  rm -rf "$TEST_DIR"
+}
+
+@test "install_packages runs apt-get update when stamp file does not exist" {
+  cat > "$TEST_DIR/apt-get" <<'MOCK'
+#!/bin/bash
+printf '%s\n' "$*" >>"$APT_GET_LOG"
+exit 0
+MOCK
+  chmod +x "$TEST_DIR/apt-get"
+
+  export APT_GET_LOG="$TEST_DIR/apt.log"
+
+  run bash -c '
+    source "$0"
+    APT_UPDATE_STAMP="$1/stamp"
+    install_packages curl
+  ' "$COMMON_SCRIPT" "$TEST_DIR"
+
+  [ "$status" -eq 0 ]
+  grep -q '^update -qq$' "$APT_GET_LOG"
+  grep -q '^install -y curl$' "$APT_GET_LOG"
+  [ -f "$TEST_DIR/stamp" ]
+}


### PR DESCRIPTION
### Motivation

- The previous implementation created the APT update stamp file up-front with `mktemp`, which caused `install_packages` to treat `apt-get update` as already run and skip it, leading to package install failures on fresh images or stale indexes.

### Description

- Change `scripts/install-tools.sh` to create a temporary directory with `mktemp -d` and set `APT_UPDATE_STAMP` to a filepath under that directory instead of precreating the stamp file.
- Update the cleanup `trap` to remove the temporary directory (`rm -rf`) so the stamp path no longer exists until `install_packages` creates it after a successful `apt-get update`. 
- Add a regression test `tests/install-tools.bats` that mocks `apt-get` to verify `install_packages` runs `apt-get update` before `apt-get install` and creates the stamp file. 
- Related Issues: Close #151

### Testing

- Ran syntax checks with `bash -n scripts/install-tools.sh` and `bash -n scripts/installers/_common.sh`, both succeeded.
- Performed a mocked run by placing a fake `apt-get` in `PATH` and invoking `install_packages`, which produced `update -qq` then `install -y <pkg>` and created the stamp file as expected.
- Added `tests/install-tools.bats` (Bats test) to assert the behavior, but `bats` was not available in the current CI environment so the new Bats test was not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a05605eddc832d8b91c0a241c17403)

## Summary by Sourcery

Ensure APT package installations always trigger an update on fresh or stale images and add coverage for this behavior.

Bug Fixes:
- Prevent install_packages from skipping apt-get update by avoiding precreation of the APT update stamp file.

Tests:
- Add a Bats test verifying install_packages runs apt-get update before apt-get install and creates the update stamp when none exists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added test coverage for package installation behavior to ensure reliability.

* **Chores**
  * Improved temporary directory management in the installation process for better cleanup procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->