### PR TITLE
fix: propagate helper installer failures and add chmod-failure test

### DIFF
--- a/scripts/installers/helper-scripts.sh
+++ b/scripts/installers/helper-scripts.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+set -u
+set -o pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+source "$SCRIPT_DIR/_common.sh"
+
+install_helper_script() {
+	local script_name="$1"
+	local source_path="$REPO_ROOT/scripts/${script_name}.sh"
+	local dest_path="$INSTALL_PREFIX/$script_name"
+
+	if [ -x "$dest_path" ]; then
+		log "$script_name already installed"
+		return 0
+	fi
+
+	if [ ! -f "$source_path" ]; then
+		fail "$source_path not found"
+		return 1
+	fi
+
+	if ! cp "$source_path" "$dest_path"; then
+		fail "failed to copy $script_name"
+		return 1
+	fi
+
+	if ! chmod +x "$dest_path"; then
+		fail "failed to mark $script_name as executable"
+		return 1
+	fi
+
+	log "$script_name installed"
+}
+
+main() {
+	local had_error=false
+
+	ensure_path || return 1
+
+	install_helper_script "lint-shell" || had_error=true
+	install_helper_script "lint-docs" || had_error=true
+
+	if [ "$had_error" = "true" ]; then
+		return 1
+	fi
+}
+
+main "$@"

--- a/scripts/lint-docs.sh
+++ b/scripts/lint-docs.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -u
+set -o pipefail
+
+exec qlty check --filter prettier "$@"

--- a/scripts/lint-shell.sh
+++ b/scripts/lint-shell.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -u
+set -o pipefail
+
+exec qlty check --filter shellcheck "$@"

--- a/tests/helper-scripts-installer.bats
+++ b/tests/helper-scripts-installer.bats
@@ -1,0 +1,66 @@
+#!/usr/bin/env bats
+
+REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/installers/helper-scripts.sh"
+
+setup() {
+	export WORK_DIR
+	WORK_DIR="$(mktemp -d)"
+
+	mkdir -p "$WORK_DIR/scripts/installers"
+	cp "$REPO_ROOT/scripts/installers/_common.sh" "$WORK_DIR/scripts/installers/_common.sh"
+	cp "$SCRIPT" "$WORK_DIR/scripts/installers/helper-scripts.sh"
+	chmod +x "$WORK_DIR/scripts/installers/helper-scripts.sh"
+
+	export INSTALL_PREFIX="$WORK_DIR/bin"
+	mkdir -p "$INSTALL_PREFIX"
+
+	# Ensure scripts are discoverable from the copied installer's REPO_ROOT.
+	mkdir -p "$WORK_DIR/scripts"
+	cat >"$WORK_DIR/scripts/lint-shell.sh" <<'SHELL'
+#!/bin/bash
+exit 0
+SHELL
+	cat >"$WORK_DIR/scripts/lint-docs.sh" <<'DOCS'
+#!/bin/bash
+exit 0
+DOCS
+	chmod +x "$WORK_DIR/scripts/lint-shell.sh" "$WORK_DIR/scripts/lint-docs.sh"
+}
+
+teardown() {
+	rm -rf "$WORK_DIR"
+}
+
+@test "installer fails when copy step fails" {
+	rm -rf "$INSTALL_PREFIX"
+	ln -s /dev/null "$INSTALL_PREFIX"
+
+	run bash "$WORK_DIR/scripts/installers/helper-scripts.sh"
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"failed to copy lint-shell"* ]]
+}
+
+@test "installer propagates failure when one helper script is missing" {
+	rm -f "$WORK_DIR/scripts/lint-docs.sh"
+
+	run bash "$WORK_DIR/scripts/installers/helper-scripts.sh"
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"lint-docs.sh not found"* ]]
+
+	[ -x "$INSTALL_PREFIX/lint-shell" ]
+}
+
+@test "installer fails when chmod step fails" {
+	mkdir -p "$WORK_DIR/fake-bin"
+	cat >"$WORK_DIR/fake-bin/chmod" <<'CHMOD'
+#!/bin/bash
+exit 1
+CHMOD
+	chmod +x "$WORK_DIR/fake-bin/chmod"
+
+	PATH="$WORK_DIR/fake-bin:$PATH" run bash "$WORK_DIR/scripts/installers/helper-scripts.sh"
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"failed to mark lint-shell as executable"* ]]
+	[ -f "$INSTALL_PREFIX/lint-shell" ]
+}


### PR DESCRIPTION
### Motivation

- Ensure helper-script installation detects `cp`/`chmod` failures and returns a non-zero exit so orchestrators can detect errors.
- Address review feedback on PR #179 to harden the installer and add missing failure-path test coverage.

### Description

- Add `scripts/installers/helper-scripts.sh` which validates source presence, fails on `cp`/`chmod` errors, and aggregates per-script failures via a `had_error` flag so the installer exits non-zero on any failure.
- Make `ensure_path` failure propagate immediately with `ensure_path || return 1` so the installer does not continue on path setup errors.
- Add concrete helper wrappers `scripts/lint-shell.sh` and `scripts/lint-docs.sh` that delegate to `qlty` with the appropriate filters.
- Add `tests/helper-scripts-installer.bats` with regression cases for copy failure, missing-source, and `chmod` failure to verify error detection and that remaining valid helpers are still installed.

Close #156

### Testing

- Ran a static syntax check with `bash -n scripts/installers/helper-scripts.sh scripts/lint-shell.sh scripts/lint-docs.sh tests/helper-scripts-installer.bats`, which succeeded.
- Attempted `bats tests/helper-scripts-installer.bats`, which failed in this environment because the `bats` command is not installed.
- Pre-commit hooks ran during commit and skipped `qlty` checks due to `qlty` not being installed, and the commit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a292512638832d93b6460a832dc800)

## Summary by Sourcery

Add a helper-script installer that robustly installs lint helper wrappers and fails on copy/permission errors, along with tests for its failure modes.

New Features:
- Introduce a helper-scripts installer to deploy lint-shell and lint-docs helper wrappers into the configured install prefix.
- Add lint-shell and lint-docs wrapper scripts that delegate to qlty with shellcheck and prettier filters respectively.

Bug Fixes:
- Ensure helper-script installation exits non-zero on copy, chmod, or missing-source failures so orchestrators can detect errors.

Tests:
- Add Bats tests covering helper installer behavior on successful installs and on copy, chmod, and missing-source failure scenarios.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shell script linting tool with integrated validation
  * Added documentation linting tool for consistency checks
  * Added installer utility for helper scripts with error handling and logging

* **Tests**
  * Added comprehensive test suite validating installer behavior, error cases, and execution permissions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->