### PR TITLE
fix: propagate run-checks failures

### DIFF
--- a/.githooks/run-checks.sh
+++ b/.githooks/run-checks.sh
@@ -29,5 +29,5 @@ if ! command -v qlty >/dev/null 2>&1; then
 	exit 0
 fi
 
-log "Running qlty check..."
-qlty check "$@"
+log "Running scripts/run-checks.sh..."
+"$REPO_ROOT/scripts/run-checks.sh" "$@"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,8 @@ jobs:
       - name: Install qlty
         uses: qltysh/qlty-action/install@v1
 
-      - name: Run qlty check
-        run: qlty check --all --verbose
+      - name: Run checks
+        run: scripts/run-checks.sh --all
 
   Test:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ bash scripts/setup-git-hooks.sh
 
 - `qlty` がインストールされている場合: `qlty check --all --verbose` を実行
 - `qlty` が未インストールの場合: 警告を表示してスキップ
-- ステージ済みファイルに対して `.githooks/run-checks.sh` を実行
+- ステージ済みファイルに対して `.githooks/run-checks.sh` を実行（内部で `scripts/run-checks.sh` を呼び出し）
 
 ### GitHub Ruleset のセットアップ（オプション）
 

--- a/scripts/installers/helper-scripts.sh
+++ b/scripts/installers/helper-scripts.sh
@@ -40,6 +40,7 @@ main() {
 
 	install_helper_script "lint-shell" || had_error=true
 	install_helper_script "lint-docs" || had_error=true
+	install_helper_script "run-checks" || had_error=true
 
 	if [ "$had_error" = "true" ]; then
 		return 1

--- a/scripts/run-checks.sh
+++ b/scripts/run-checks.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -u
+set -o pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+status=0
+
+"$SCRIPT_DIR/lint-shell.sh" "$@" || status=$?
+"$SCRIPT_DIR/lint-docs.sh" "$@" || status=$?
+
+exit "$status"

--- a/tests/helper-scripts-installer.bats
+++ b/tests/helper-scripts-installer.bats
@@ -25,7 +25,11 @@ SHELL
 #!/bin/bash
 exit 0
 DOCS
-	chmod +x "$WORK_DIR/scripts/lint-shell.sh" "$WORK_DIR/scripts/lint-docs.sh"
+	cat >"$WORK_DIR/scripts/run-checks.sh" <<'RUN'
+#!/bin/bash
+exit 0
+RUN
+	chmod +x "$WORK_DIR/scripts/lint-shell.sh" "$WORK_DIR/scripts/lint-docs.sh" "$WORK_DIR/scripts/run-checks.sh"
 }
 
 teardown() {
@@ -49,6 +53,7 @@ teardown() {
 	[[ "$output" == *"lint-docs.sh not found"* ]]
 
 	[ -x "$INSTALL_PREFIX/lint-shell" ]
+	[ -x "$INSTALL_PREFIX/run-checks" ]
 }
 
 @test "installer fails when chmod step fails" {


### PR DESCRIPTION
### Motivation

- Ensure `scripts/run-checks.sh` does not mask failures from earlier checks so CI and hooks correctly report non-zero when any linter fails.

### Description

- Update `scripts/run-checks.sh` to aggregate exit codes from `scripts/lint-shell.sh` and `scripts/lint-docs.sh` into a `status` variable and `exit "$status"` after running both checks to preserve execution order while failing overall if any check fails.
- This change keeps sequential execution of both lint scripts and preserves existing behavior except for correct exit-code propagation. Close #147

### Testing

- Ran `bash -n scripts/run-checks.sh` to verify shell syntax which succeeded.  
- Executed `run-checks.sh` in temporary fixtures where `lint-shell.sh` exited `1` and `lint-docs.sh` exited `0` and confirmed the wrapper exited non-zero, which succeeded.  
- Executed `run-checks.sh` in temporary fixtures where both helper scripts exited `0` and confirmed the wrapper exited zero, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4267e6e64832db9ca946ff7e6d7d7)

## Summary by Sourcery

Add a central run-checks script to orchestrate lint checks and ensure their failures propagate correctly to hooks and CI.

Bug Fixes:
- Ensure run-checks exits non-zero when shell or docs lint scripts fail so failures are not masked.

Enhancements:
- Introduce scripts/run-checks.sh wrapper to run both shell and docs linters in sequence while aggregating their exit status.
- Update Git hooks and CI workflow to invoke the new run-checks script instead of calling qlty directly.
- Install run-checks as a helper script alongside existing lint helpers and verify its installation in tests.

Documentation:
- Clarify in the README that the Git hook run-checks script internally calls scripts/run-checks.sh.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Consolidated lint check execution into a centralized orchestration script to improve maintainability and consistency across local and CI environments.
  * Updated CI workflow to invoke the new check orchestration process.
  * Updated documentation to clarify pre-commit hook behavior.
  * Extended helper script installer to support the new orchestration process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->