### PR TITLE
fix: run all qlty plugins in run-checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         uses: qltysh/qlty-action/install@v1
 
       - name: Run checks
-        run: scripts/run-checks.sh --all
+        run: scripts/run-checks.sh
 
   Test:
     runs-on: ubuntu-latest

--- a/.qlty/qlty.toml
+++ b/.qlty/qlty.toml
@@ -1,3 +1,8 @@
+# NOTE:
+# CI and helper script `scripts/run-checks.sh` run `qlty check --all`.
+# Keep this plugin list as the single source of truth for checks,
+# including shfmt/actionlint for shell formatting and GitHub Actions linting.
+
 config_version = "0"
 
 [[source]]

--- a/scripts/run-checks.sh
+++ b/scripts/run-checks.sh
@@ -2,4 +2,4 @@
 set -u
 set -o pipefail
 
-exec qlty check "$@"
+exec qlty check --all "$@"


### PR DESCRIPTION
### Motivation

- Restore CI lint coverage after `run-checks.sh` was changed to only invoke `lint-shell.sh` and `lint-docs.sh`, which skipped plugins configured in `.qlty/qlty.toml` such as `shfmt` and `actionlint`.

### Description

- Replace the previous partial-plugin invocation with a single `exec qlty check "$@"` in `scripts/run-checks.sh` so all configured qlty plugins run.
- Remove the wrapper logic that only executed `lint-shell.sh` and `lint-docs.sh` to avoid missed checks.
- Close #192

### Testing

- `bash -n scripts/run-checks.sh` succeeded (shell syntax check passed).
- Running `scripts/run-checks.sh --help` failed in this environment because the `qlty` binary is not installed, as expected in the container. 
- `bats tests/helper-scripts-installer.bats` could not be executed in this environment because `bats` is not installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a43366a548832da6001d778ae8be7f)

## Summary by Sourcery

Restore the run-checks script to invoke the full qlty check suite instead of partial lint wrappers.

Bug Fixes:
- Ensure all qlty-configured plugins (e.g., shfmt, actionlint) are executed when running the checks script.

Build:
- Simplify the run-checks helper script to delegate directly to `qlty check` for CI linting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Linting workflow simplified: the verification now delegates to a single check tool and the process exit is determined by that tool.
  * CI step adjusted to rely on the script's default invocation, aligning workflow behavior with the simplified check approach.

* **Documentation**
  * Configuration comments updated to document the check behavior and the canonical plugin list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->