### PR TITLE
Add bats installer and enable bats tests in CI

### DIFF
--- a/.github/scripts/tests/setup-all.bats
+++ b/.github/scripts/tests/setup-all.bats
@@ -3,13 +3,16 @@
 # setup-all.sh のテスト
 
 # batsライブラリを環境に応じて読み込む
-# Ubuntu: /usr/lib/bats-support, macOS (Homebrew): /usr/local/lib/bats
 if [ -f "/usr/lib/bats-support/load.bash" ]; then
-    # Ubuntu (apt install bats-support bats-assert)
+    # Ubuntu (focal/jammy)
     load "/usr/lib/bats-support/load.bash"
     load "/usr/lib/bats-assert/load.bash"
+elif [ -f "/usr/lib/bats/bats-support/load.bash" ]; then
+    # Ubuntu (noble+)
+    load "/usr/lib/bats/bats-support/load.bash"
+    load "/usr/lib/bats/bats-assert/load.bash"
 elif [ -f "/usr/local/lib/bats/bats-support/load" ]; then
-    # macOS Homebrew
+    # macOS Homebrew (Intel)
     load "/usr/local/lib/bats/bats-support/load"
     load "/usr/local/lib/bats/bats-assert/load"
 elif [ -f "/opt/homebrew/lib/bats/bats-support/load" ]; then
@@ -21,7 +24,7 @@ fi
 setup() {
     # テスト用の一時ディレクトリを作成
     TEST_DIR=$(mktemp -d)
-    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+    SCRIPT_DIR="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
     
     # モック用のパスを設定
     export PATH="$TEST_DIR:$PATH"

--- a/.github/scripts/tests/setup-branch-auto-delete.bats
+++ b/.github/scripts/tests/setup-branch-auto-delete.bats
@@ -3,13 +3,16 @@
 # setup-branch-auto-delete.sh のテスト
 
 # batsライブラリを環境に応じて読み込む
-# Ubuntu: /usr/lib/bats-support, macOS (Homebrew): /usr/local/lib/bats
 if [ -f "/usr/lib/bats-support/load.bash" ]; then
-    # Ubuntu (apt install bats-support bats-assert)
+    # Ubuntu (focal/jammy)
     load "/usr/lib/bats-support/load.bash"
     load "/usr/lib/bats-assert/load.bash"
+elif [ -f "/usr/lib/bats/bats-support/load.bash" ]; then
+    # Ubuntu (noble+)
+    load "/usr/lib/bats/bats-support/load.bash"
+    load "/usr/lib/bats/bats-assert/load.bash"
 elif [ -f "/usr/local/lib/bats/bats-support/load" ]; then
-    # macOS Homebrew
+    # macOS Homebrew (Intel)
     load "/usr/local/lib/bats/bats-support/load"
     load "/usr/local/lib/bats/bats-assert/load"
 elif [ -f "/opt/homebrew/lib/bats/bats-support/load" ]; then
@@ -21,7 +24,7 @@ fi
 setup() {
     # テスト用の一時ディレクトリを作成
     TEST_DIR=$(mktemp -d)
-    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+    SCRIPT_DIR="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
     
     # モック用のパスを設定
     export PATH="$TEST_DIR:$PATH"

--- a/.github/scripts/tests/setup-branch-update-suggestion.bats
+++ b/.github/scripts/tests/setup-branch-update-suggestion.bats
@@ -3,13 +3,16 @@
 # setup-branch-update-suggestion.sh のテスト
 
 # batsライブラリを環境に応じて読み込む
-# Ubuntu: /usr/lib/bats-support, macOS (Homebrew): /usr/local/lib/bats
 if [ -f "/usr/lib/bats-support/load.bash" ]; then
-    # Ubuntu (apt install bats-support bats-assert)
+    # Ubuntu (focal/jammy)
     load "/usr/lib/bats-support/load.bash"
     load "/usr/lib/bats-assert/load.bash"
+elif [ -f "/usr/lib/bats/bats-support/load.bash" ]; then
+    # Ubuntu (noble+)
+    load "/usr/lib/bats/bats-support/load.bash"
+    load "/usr/lib/bats/bats-assert/load.bash"
 elif [ -f "/usr/local/lib/bats/bats-support/load" ]; then
-    # macOS Homebrew
+    # macOS Homebrew (Intel)
     load "/usr/local/lib/bats/bats-support/load"
     load "/usr/local/lib/bats/bats-assert/load"
 elif [ -f "/opt/homebrew/lib/bats/bats-support/load" ]; then
@@ -21,7 +24,7 @@ fi
 setup() {
     # テスト用の一時ディレクトリを作成
     TEST_DIR=$(mktemp -d)
-    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+    SCRIPT_DIR="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
 
     # モック用のパスを設定
     export PATH="$TEST_DIR:$PATH"

--- a/.github/scripts/tests/setup-github-project.bats
+++ b/.github/scripts/tests/setup-github-project.bats
@@ -3,13 +3,16 @@
 # setup-github-project.sh のテスト
 
 # batsライブラリを環境に応じて読み込む
-# Ubuntu: /usr/lib/bats-support, macOS (Homebrew): /usr/local/lib/bats
 if [ -f "/usr/lib/bats-support/load.bash" ]; then
-    # Ubuntu (apt install bats-support bats-assert)
+    # Ubuntu (focal/jammy)
     load "/usr/lib/bats-support/load.bash"
     load "/usr/lib/bats-assert/load.bash"
+elif [ -f "/usr/lib/bats/bats-support/load.bash" ]; then
+    # Ubuntu (noble+)
+    load "/usr/lib/bats/bats-support/load.bash"
+    load "/usr/lib/bats/bats-assert/load.bash"
 elif [ -f "/usr/local/lib/bats/bats-support/load" ]; then
-    # macOS Homebrew
+    # macOS Homebrew (Intel)
     load "/usr/local/lib/bats/bats-support/load"
     load "/usr/local/lib/bats/bats-assert/load"
 elif [ -f "/opt/homebrew/lib/bats/bats-support/load" ]; then
@@ -21,7 +24,7 @@ fi
 setup() {
     # テスト用の一時ディレクトリを作成
     TEST_DIR=$(mktemp -d)
-    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+    SCRIPT_DIR="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
 
     # モック用のパスを設定
     export PATH="$TEST_DIR:$PATH"

--- a/.github/scripts/tests/setup-labels.bats
+++ b/.github/scripts/tests/setup-labels.bats
@@ -3,13 +3,16 @@
 # setup-labels.sh のテスト
 
 # batsライブラリを環境に応じて読み込む
-# Ubuntu: /usr/lib/bats-support, macOS (Homebrew): /usr/local/lib/bats
 if [ -f "/usr/lib/bats-support/load.bash" ]; then
-    # Ubuntu (apt install bats-support bats-assert)
+    # Ubuntu (focal/jammy)
     load "/usr/lib/bats-support/load.bash"
     load "/usr/lib/bats-assert/load.bash"
+elif [ -f "/usr/lib/bats/bats-support/load.bash" ]; then
+    # Ubuntu (noble+)
+    load "/usr/lib/bats/bats-support/load.bash"
+    load "/usr/lib/bats/bats-assert/load.bash"
 elif [ -f "/usr/local/lib/bats/bats-support/load" ]; then
-    # macOS Homebrew
+    # macOS Homebrew (Intel)
     load "/usr/local/lib/bats/bats-support/load"
     load "/usr/local/lib/bats/bats-assert/load"
 elif [ -f "/opt/homebrew/lib/bats/bats-support/load" ]; then
@@ -21,7 +24,7 @@ fi
 setup() {
     # テスト用の一時ディレクトリを作成
     TEST_DIR=$(mktemp -d)
-    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+    SCRIPT_DIR="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
 
     # モック用のパスを設定
     export PATH="$TEST_DIR:$PATH"

--- a/.github/scripts/tests/setup-rulesets.bats
+++ b/.github/scripts/tests/setup-rulesets.bats
@@ -3,13 +3,16 @@
 # setup-rulesets.sh のテスト
 
 # batsライブラリを環境に応じて読み込む
-# Ubuntu: /usr/lib/bats-support, macOS (Homebrew): /usr/local/lib/bats
 if [ -f "/usr/lib/bats-support/load.bash" ]; then
-    # Ubuntu (apt install bats-support bats-assert)
+    # Ubuntu (focal/jammy)
     load "/usr/lib/bats-support/load.bash"
     load "/usr/lib/bats-assert/load.bash"
+elif [ -f "/usr/lib/bats/bats-support/load.bash" ]; then
+    # Ubuntu (noble+)
+    load "/usr/lib/bats/bats-support/load.bash"
+    load "/usr/lib/bats/bats-assert/load.bash"
 elif [ -f "/usr/local/lib/bats/bats-support/load" ]; then
-    # macOS Homebrew
+    # macOS Homebrew (Intel)
     load "/usr/local/lib/bats/bats-support/load"
     load "/usr/local/lib/bats/bats-assert/load"
 elif [ -f "/opt/homebrew/lib/bats/bats-support/load" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,19 @@ jobs:
         run: scripts/run-checks.sh --all
 
   Test:
+    name: bats Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
-      - name: Run tests
-        run: echo "Add your test commands here"
+
+      - name: Install bats tooling
+        run: SKIP_INSTALLERS=qlty STRICT_MODE=true bash scripts/install-tools.sh
+
+      - name: Run bats tests
+        run: |
+          bats .github/scripts/tests/*.bats
+          bats tests/*.bats

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Shell Development Environment
 # This Dockerfile provides a complete shell script development environment
-# with qlty and bats-core installed.
+# with qlty and bats-related tooling installed.
 
 FROM ubuntu:22.04
 
@@ -10,7 +10,6 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Install prerequisites for tool installation
 RUN apt-get update && \
     apt-get install -y \
-    bats \
     ca-certificates \
     curl \
     git \

--- a/scripts/install-tools.sh
+++ b/scripts/install-tools.sh
@@ -24,6 +24,7 @@ should_skip() {
 
 main() {
 	local installers=(
+		bats
 		qlty
 	)
 	local apt_stamp_dir

--- a/scripts/installers/bats.sh
+++ b/scripts/installers/bats.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -u
+set -o pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+source "$SCRIPT_DIR/_common.sh"
+
+main() {
+	log "Installing bats-core and helper libraries..."
+	if ! install_packages bats bats-support bats-assert; then
+		fail "failed to install bats packages"
+		return 1
+	fi
+
+	log "bats-core and helper libraries installed successfully"
+}
+
+main "$@"

--- a/tests/bats-installer.bats
+++ b/tests/bats-installer.bats
@@ -1,0 +1,34 @@
+#!/usr/bin/env bats
+
+REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+
+setup() {
+  export WORK_DIR
+  WORK_DIR="$(mktemp -d)"
+  export APT_GET_LOG="$WORK_DIR/apt-get.log"
+
+  mkdir -p "$WORK_DIR/bin"
+
+  cat > "$WORK_DIR/bin/apt-get" <<'APT'
+#!/bin/bash
+printf '%s\n' "$*" >>"$APT_GET_LOG"
+exit 0
+APT
+  chmod +x "$WORK_DIR/bin/apt-get"
+
+  export PATH="$WORK_DIR/bin:$PATH"
+}
+
+teardown() {
+  rm -rf "$WORK_DIR"
+}
+
+@test "bats installer installs bats and helper libraries via apt" {
+  export APT_UPDATE_STAMP="$WORK_DIR/apt-update.stamp"
+
+  run bash "$REPO_ROOT/scripts/installers/bats.sh"
+  [ "$status" -eq 0 ]
+
+  grep -q '^update -qq$' "$APT_GET_LOG"
+  grep -q '^install -y bats bats-support bats-assert$' "$APT_GET_LOG"
+}


### PR DESCRIPTION
### Motivation
- Issue #183 identified that `bats` and its helper libraries are not installable via the repository installers and CI does not run the existing bats tests.
- The goal is to provide a repository-level installer for `bats` and run the bats suites in CI to improve test coverage and developer ergonomics.

### Description
- Added a new installer `scripts/installers/bats.sh` that installs `bats`, `bats-support`, and `bats-assert` via `apt` using the shared installer helpers. Close #183
- Updated `scripts/install-tools.sh` to include the `bats` installer in the orchestrated installers list so `bats` can be installed via the common flow.
- Removed direct `bats` installation from the `Dockerfile` and made the Dockerfile rely on the shared installer (`scripts/install-tools.sh`) for consistency.
- Updated the CI workflow `.github/workflows/ci.yml` Test job to install bats tooling and run `bats .github/scripts/tests/*.bats` and `bats tests/*.bats` instead of the placeholder command.
- Added `tests/bats-installer.bats` to verify the new installer calls `apt-get update` and installs the expected packages, and updated `.github/scripts/tests/*.bats` to support additional Ubuntu layout paths and to use `BATS_TEST_DIRNAME` for correct path resolution.

### Testing
- Ran `SKIP_INSTALLERS=qlty STRICT_MODE=true bash scripts/install-tools.sh` which completed successfully and installed `bats` when requested (passed).
- Ran `bats tests/*.bats` which passed (new `tests/bats-installer.bats` and existing `tests/*` passed).
- Ran `bats .github/scripts/tests/*.bats` which runs the repository scripts test suite; the suite mostly passes after path/fix updates but some tests still fail due to existing expectations (executable permission checks and a few message/fixture expectations); these remaining failures are documented and left for follow-up.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a43384c78c832d8f07958b5cd0170f)

## Summary by Sourcery

Add a repository-level bats installer, integrate bats-based tests into CI, and align the Docker environment and scripts with the shared installation flow.

New Features:
- Provide a bats installer script that installs bats and its helper libraries via the shared installer framework.
- Enable running repository bats test suites as part of the CI Test job.

Enhancements:
- Update bats test scripts to support multiple Ubuntu and macOS layout paths and to use BATS_TEST_DIRNAME for robust path resolution.
- Have the Docker image rely on the shared install-tools script for bats-related tooling instead of installing bats directly.

Tests:
- Add a bats test to verify the bats installer invokes apt-get update and installs the expected packages.