### PR TITLE
fix: stabilize bats tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,17 @@ jobs:
         run: scripts/run-checks.sh --all
 
   Test:
+    name: bats Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
-      - name: Run tests
-        run: echo "Add your test commands here"
+
+      - name: Install bats tooling
+        run: SKIP_INSTALLERS=qlty STRICT_MODE=true bash scripts/install-tools.sh
+
+      - name: Run bats tests
+        run: bats tests/*.bats

--- a/tests/install-tools.bats
+++ b/tests/install-tools.bats
@@ -16,6 +16,12 @@ exit 0
 APT
   chmod +x "$WORK_DIR/bin/apt-get"
 
+  cat > "$WORK_DIR/bin/sudo" <<'SUDO'
+#!/bin/bash
+"$@"
+SUDO
+  chmod +x "$WORK_DIR/bin/sudo"
+
   export PATH="$WORK_DIR/bin:$PATH"
 }
 


### PR DESCRIPTION
### Motivation

- Ensure `tests/install-tools.bats` deterministically exercises the `apt-get` stub even when CI runs as a non-root user that invokes `sudo`.
- Replace the CI `Test` placeholder with a reproducible bats invocation while avoiding known-failing `.github/scripts/tests/*.bats` from blocking merges.

### Description

- Add a `sudo` stub to `tests/install-tools.bats` `setup()` so `sudo apt-get ...` calls still resolve to the mocked `apt-get` in the test `PATH`.
- Update `.github/workflows/ci.yml` `Test` job to install bats tooling via `SKIP_INSTALLERS=qlty STRICT_MODE=true bash scripts/install-tools.sh` and run `bats tests/*.bats` so only the repository-level tests are executed in CI.
- This PR closes the related issue: Close #195

### Testing

- Committed the changes and pre-commit hooks ran (qlty was not installed so qlty checks were skipped) and the commit succeeded.
- Verified `bats` is not available in the current environment with `command -v bats >/dev/null && bats tests/*.bats || echo 'bats not installed'`, which printed `bats not installed`.
- Attempted lightweight shell validation with `bash -n` where applicable; the `tests/install-tools.bats` file cannot be validated by `bash -n` because it uses bats `@test` syntax while shell scripts remain subject to normal shell syntax checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a43d25e4fc832d91596df9c6cc8bff)

## Summary by Sourcery

Stabilize bats-based testing in CI by correctly mocking sudo in tests and wiring bats test execution into the CI workflow.

Bug Fixes:
- Ensure install-tools bats tests correctly exercise the apt-get stub even when commands are invoked via sudo.

Tests:
- Add a sudo stub to install-tools.bats so sudo apt-get calls use the mocked apt-get binary in the test PATH.
- Update the CI Test job to install bats tooling and execute repository-level bats tests instead of a placeholder command.