### PR TITLE
feat: add dotenvx installer to install-tools flow

### DIFF
--- a/scripts/install-tools.sh
+++ b/scripts/install-tools.sh
@@ -24,6 +24,7 @@ should_skip() {
 
 main() {
 	local installers=(
+		dotenvx
 		qlty
 	)
 	local apt_stamp_dir

--- a/scripts/installers/dotenvx.sh
+++ b/scripts/installers/dotenvx.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -u
+set -o pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+source "$SCRIPT_DIR/_common.sh"
+
+main() {
+	ensure_path
+
+	if command_exists dotenvx; then
+		log "dotenvx already installed: $(dotenvx --version)"
+		return 0
+	fi
+
+	log "Installing dotenvx..."
+	if ! curl -sfS https://dotenvx.sh | sh; then
+		fail "failed to install dotenvx"
+		return 1
+	fi
+
+	if ! command_exists dotenvx; then
+		fail "dotenvx command not found after install"
+		return 1
+	fi
+
+	log "dotenvx installed successfully: $(dotenvx --version)"
+}
+
+main "$@"


### PR DESCRIPTION
### Motivation

- Provide an automated installer for `dotenvx` so the project setup installs it when missing during environment bootstrap.
- Close #201.

### Description

- Add `scripts/installers/dotenvx.sh` which sources `_common.sh`, runs `ensure_path`, skips when `dotenvx` is present, installs via `curl -sfS https://dotenvx.sh | sh`, verifies the command is available, and logs the installed version.
- Wire `dotenvx` into the orchestration by adding it to the `installers` array in `scripts/install-tools.sh` so it runs as part of the tool installation flow.

### Testing

- Ran `bash -n scripts/installers/dotenvx.sh scripts/install-tools.sh` to validate shell syntax and it passed.
- Executed `SKIP_INSTALLERS='dotenvx,qlty' bash scripts/install-tools.sh` to exercise the installer orchestration and it completed successfully.
- Attempted to run `bats tests/install-tools.bats tests/helper-scripts-installer.bats` but the `bats` command is not available in this environment so those test suites could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a84292cb70832d9137250e23ec188c)

## Summary by Sourcery

Add dotenvx to the automated tool installation flow so it is installed during environment bootstrap when missing.

New Features:
- Introduce a dotenvx installer script that installs dotenvx if not already present and reports its version.
- Include dotenvx in the centralized install-tools orchestration so it runs alongside existing tool installers.