### PR TITLE
feat: add dotenvx SessionStart hook

### DIFF
--- a/.claude/hooks/dotenvx-load.sh
+++ b/.claude/hooks/dotenvx-load.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -e
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ENV_PATH="$REPO_ROOT/.env"
+
+log_warn() {
+	echo "[dotenvx-load] $*" >&2
+}
+
+if ! command -v dotenvx >/dev/null 2>&1; then
+	log_warn "dotenvx is not installed; skipping .env load"
+	exit 0
+fi
+
+if [ -z "${DOTENV_KEY:-}" ]; then
+	log_warn "DOTENV_KEY is not set; skipping .env load"
+	exit 0
+fi
+
+if [ ! -f "$ENV_PATH" ]; then
+	log_warn ".env file not found at $ENV_PATH; skipping .env load"
+	exit 0
+fi
+
+if ! eval "$(cd "$REPO_ROOT" && dotenvx get --format=shell)"; then
+	log_warn "failed to load environment variables via dotenvx"
+	exit 0
+fi
+
+log_warn "loaded environment variables from .env"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,6 +6,10 @@
         "hooks": [
           {
             "type": "command",
+            "command": "./.claude/hooks/dotenvx-load.sh"
+          },
+          {
+            "type": "command",
             "command": "./.claude/hooks/gh-setup.sh"
           }
         ]

--- a/tests/claude-dotenvx-load-hook.bats
+++ b/tests/claude-dotenvx-load-hook.bats
@@ -1,0 +1,69 @@
+#!/usr/bin/env bats
+
+REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+SCRIPT="$REPO_ROOT/.claude/hooks/dotenvx-load.sh"
+
+setup() {
+  export WORK_DIR
+  WORK_DIR="$(mktemp -d)"
+
+  mkdir -p "$WORK_DIR/.claude/hooks" "$WORK_DIR/bin"
+  cp "$SCRIPT" "$WORK_DIR/.claude/hooks/dotenvx-load.sh"
+
+  export PATH="$WORK_DIR/bin:$PATH"
+}
+
+teardown() {
+  rm -rf "$WORK_DIR"
+}
+
+@test "dotenvx-load exits successfully when dotenvx is missing" {
+  run bash "$WORK_DIR/.claude/hooks/dotenvx-load.sh"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"dotenvx is not installed"* ]]
+}
+
+@test "dotenvx-load exits successfully when DOTENV_KEY is missing" {
+  cat >"$WORK_DIR/bin/dotenvx" <<'DOTENVX'
+#!/bin/bash
+exit 0
+DOTENVX
+  chmod +x "$WORK_DIR/bin/dotenvx"
+
+  run bash "$WORK_DIR/.claude/hooks/dotenvx-load.sh"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"DOTENV_KEY is not set"* ]]
+}
+
+@test "dotenvx-load exits successfully when .env is missing" {
+  cat >"$WORK_DIR/bin/dotenvx" <<'DOTENVX'
+#!/bin/bash
+exit 0
+DOTENVX
+  chmod +x "$WORK_DIR/bin/dotenvx"
+
+  export DOTENV_KEY="dummy-key"
+
+  run bash "$WORK_DIR/.claude/hooks/dotenvx-load.sh"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *".env file not found"* ]]
+}
+
+@test "dotenvx-load evaluates dotenvx output when prerequisites are met" {
+  cat >"$WORK_DIR/bin/dotenvx" <<'DOTENVX'
+#!/bin/bash
+if [ "$1" = "get" ] && [ "$2" = "--format=shell" ]; then
+  echo "export LOADED_FROM_DOTENVX=ok"
+  exit 0
+fi
+exit 1
+DOTENVX
+  chmod +x "$WORK_DIR/bin/dotenvx"
+
+  touch "$WORK_DIR/.env"
+  export DOTENV_KEY="dummy-key"
+
+  run bash -c 'source "$1" && echo "$LOADED_FROM_DOTENVX"' _ "$WORK_DIR/.claude/hooks/dotenvx-load.sh"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"ok"* ]]
+}


### PR DESCRIPTION
### Motivation

- Implement issue #199 to auto-load repository `.env` values into SessionStart using `dotenvx` so encrypted envs are available to session tooling.
- Ensure the hook is safe to run and silently skips with warnings when `dotenvx` is not installed, `DOTENV_KEY` is unset, or `.env` is absent.

### Description

- Add `.claude/hooks/dotenvx-load.sh` which checks `dotenvx`, `DOTENV_KEY`, and `.env`, then runs `dotenvx get --format=shell` and `eval`s the output to load environment variables.
- Register the new script in `.claude/settings.json`'s `SessionStart` hooks so it runs before the existing `gh-setup.sh` hook.
- Add `tests/claude-dotenvx-load-hook.bats` with cases for missing `dotenvx`, missing `DOTENV_KEY`, missing `.env`, and a successful evaluation path.
- Close #199

### Testing

- Ran `bash -n .claude/hooks/dotenvx-load.sh` to validate shell syntax, and it succeeded.
- Attempted to run `bats tests/claude-dotenvx-load-hook.bats`, but the command failed because `bats` is not installed in the environment.
- Executed automated runtime checks that stubbed `dotenvx` in `PATH` and sourced the hook in a temporary workspace, and also parsed `.claude/settings.json` as JSON; these automated checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad1c04418c832d891c679495123e1a)

## Summary by Sourcery

Add a SessionStart hook that loads repository .env variables via dotenvx when available and safe to do so.

New Features:
- Introduce a dotenvx-based hook script to load encrypted .env environment variables at session start.

Tests:
- Add Bats tests covering dotenvx-load hook behavior for missing prerequisites and successful environment loading.