### PR TITLE
Manage GitHub Rulesets with Terraform and integrate install-tools into Codex setup

### DIFF
--- a/.codex/hooks/codex-setup.sh
+++ b/.codex/hooks/codex-setup.sh
@@ -16,22 +16,29 @@ REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
 log "Starting Codex setup..."
 
 if [ "${CODEX_REMOTE:-}" = "true" ]; then
-	log "1/5 Removing git remote origin..."
+	log "1/6 Removing git remote origin..."
 	git -C "$REPO_ROOT" remote remove origin 2>/dev/null || true
 else
-	log "1/5 Skipping git remote removal (not a remote session)"
+	log "1/6 Skipping git remote removal (not a remote session)"
 fi
 
-log "2/5 Running gh CLI setup..."
+log "2/6 Running gh CLI setup..."
 bash "$REPO_ROOT/.codex/hooks/gh-setup.sh"
 
-log "3/5 Running environment setup..."
-bash "$REPO_ROOT/.codex/hooks/env-setup.sh"
 
-log "4/5 Syncing skills directory..."
+log "3/6 Installing development tools via scripts/install-tools.sh..."
+INSTALL_PREFIX="${HOME}/.local/bin" \
+ENV_FILE="${CODEX_ENV_FILE:-}" \
+STRICT_MODE="false" \
+	bash "$REPO_ROOT/scripts/install-tools.sh"
+
+log "4/6 Running environment setup..."
+CODEX_SKIP_TOOL_INSTALL=1 bash "$REPO_ROOT/.codex/hooks/env-setup.sh"
+
+log "5/6 Syncing skills directory..."
 bash "$REPO_ROOT/.claude/hooks/skills-setup.sh"
 
-log "5/5 Configuring git hooks..."
+log "6/6 Configuring git hooks..."
 bash "$REPO_ROOT/scripts/setup-git-hooks.sh"
 
 log "Codex setup completed successfully."

--- a/.codex/hooks/env-setup.sh
+++ b/.codex/hooks/env-setup.sh
@@ -22,6 +22,10 @@ export INSTALL_PREFIX
 export ENV_FILE
 export STRICT_MODE
 
-bash "$REPO_ROOT/scripts/install-tools.sh"
+if [ "${CODEX_SKIP_TOOL_INSTALL:-0}" = "1" ]; then
+	log "Skipping install-tools.sh (already handled by caller)"
+else
+	bash "$REPO_ROOT/scripts/install-tools.sh"
+fi
 
 log "Development environment setup completed successfully!"

--- a/.github/scripts/setup-all.sh
+++ b/.github/scripts/setup-all.sh
@@ -35,11 +35,10 @@ run_script() {
 	echo ""
 }
 
-run_script "1" "Ruleset のセットアップ" "$SCRIPT_DIR/setup-rulesets.sh"
-run_script "2" "ラベルの設定" "$SCRIPT_DIR/setup-labels.sh"
-run_script "3" "GitHub Project のセットアップ" "$SCRIPT_DIR/setup-github-project.sh"
+run_script "1" "ラベルの設定" "$SCRIPT_DIR/setup-labels.sh"
+run_script "2" "GitHub Project のセットアップ" "$SCRIPT_DIR/setup-github-project.sh"
 
-echo "※ ブランチ自動削除と PR ブランチ更新提案は Terraform で管理します"
+echo "※ Ruleset とリポジトリ保護設定は Terraform で管理します"
 echo "   .github/terraform/repository-settings/README.md を参照してください"
 echo ""
 

--- a/.github/scripts/tests/setup-all.bats
+++ b/.github/scripts/tests/setup-all.bats
@@ -47,18 +47,6 @@ teardown() {
 
 @test "setup-all.sh が他のスクリプトを呼び出す" {
     # モックスクリプトを作成
-    cat > "$TEST_DIR/setup-rulesets.sh" <<'EOF'
-#!/bin/bash
-echo "setup-rulesets.sh called"
-EOF
-    chmod +x "$TEST_DIR/setup-rulesets.sh"
-
-    cat > "$TEST_DIR/setup-branch-auto-delete.sh" <<'EOF'
-#!/bin/bash
-echo "setup-branch-auto-delete.sh called"
-EOF
-    chmod +x "$TEST_DIR/setup-branch-auto-delete.sh"
-
     cat > "$TEST_DIR/setup-labels.sh" <<'EOF'
 #!/bin/bash
 echo "setup-labels.sh called"

--- a/.github/terraform/repository-settings/README.md
+++ b/.github/terraform/repository-settings/README.md
@@ -1,11 +1,19 @@
 # Repository settings Terraform
 
-`github_repository` リソースで、リポジトリの基本設定を管理します。
+`github_repository` と `github_repository_ruleset` リソースで、
+リポジトリの基本設定と Ruleset を管理します。
 
 ## 管理対象
 
 - `delete_branch_on_merge = true`
 - `allow_update_branch = true`
+- `Branch Protection Ruleset`
+  - `refs/heads/main`
+  - `refs/heads/develop`
+  - `refs/heads/release/*`
+- `Feature Branch Ruleset`
+  - `refs/heads/feature/*`
+  - `refs/heads/feat/*`
 
 ## 使い方
 
@@ -22,10 +30,18 @@ export TF_VAR_repository_name="template"
 export TF_VAR_github_token="<PAT>"
 ```
 
-既存リポジトリを import します。
+既存設定を import します。
 
 ```bash
 terraform import github_repository.template template
+terraform import github_repository_ruleset.branch_protection <branch-protection-ruleset-id>
+terraform import github_repository_ruleset.feature_branch <feature-branch-ruleset-id>
+```
+
+Ruleset ID の確認:
+
+```bash
+gh api repos/OWNER/REPO/rulesets --jq '.[] | {id: .id, name: .name}'
 ```
 
 差分確認:
@@ -34,8 +50,15 @@ terraform import github_repository.template template
 terraform plan
 ```
 
+適用:
+
+```bash
+terraform apply
+```
+
 ## 補足
 
 - 旧スクリプト `.github/scripts/setup-branch-auto-delete.sh` と
   `.github/scripts/setup-branch-update-suggestion.sh` は、Terraform 移行後に削除予定です。
-- `terraform plan` がゼロ差分になることを確認してから削除してください。
+- 旧 Ruleset JSON と `setup-rulesets.sh` は互換目的で残しています。
+- `terraform plan` がゼロ差分になることを確認してから不要な資産を整理してください。

--- a/.github/terraform/repository-settings/main.tf
+++ b/.github/terraform/repository-settings/main.tf
@@ -20,3 +20,82 @@ resource "github_repository" "template" {
   delete_branch_on_merge = true
   allow_update_branch    = true
 }
+
+resource "github_repository_ruleset" "branch_protection" {
+  name        = "Branch Protection Ruleset"
+  repository  = github_repository.template.name
+  target      = "branch"
+  enforcement = "active"
+
+  conditions {
+    ref_name {
+      include = [
+        "refs/heads/main",
+        "refs/heads/develop",
+        "refs/heads/release/*"
+      ]
+      exclude = []
+    }
+  }
+
+  rules {
+    deletion         = true
+    non_fast_forward = true
+    update           = true
+
+    pull_request {
+      required_approving_review_count = 1
+      dismiss_stale_reviews_on_push   = true
+      require_code_owner_review       = false
+      require_last_push_approval      = false
+      required_review_thread_resolution = false
+    }
+
+    required_status_checks {
+      strict_required_status_checks_policy = true
+
+      required_check {
+        context = "ci"
+      }
+    }
+  }
+
+  bypass_actors {
+    actor_id    = 5
+    actor_type  = "RepositoryRole"
+    bypass_mode = "always"
+  }
+}
+
+resource "github_repository_ruleset" "feature_branch" {
+  name        = "Feature Branch Ruleset"
+  repository  = github_repository.template.name
+  target      = "branch"
+  enforcement = "active"
+
+  conditions {
+    ref_name {
+      include = [
+        "refs/heads/feature/*",
+        "refs/heads/feat/*"
+      ]
+      exclude = []
+    }
+  }
+
+  rules {
+    pull_request {
+      required_approving_review_count = 1
+      dismiss_stale_reviews_on_push   = true
+      require_code_owner_review       = false
+      require_last_push_approval      = false
+      required_review_thread_resolution = false
+    }
+  }
+
+  bypass_actors {
+    actor_id    = 5
+    actor_type  = "RepositoryRole"
+    bypass_mode = "always"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -35,13 +35,9 @@ CI/CD、コードレビュー、コード品質チェックなどの自動化ワ
 
 統一されたPull Request形式を提供するテンプレートです。
 
-### `.github/rulesets/`
-
-ブランチ保護ルールやフィーチャーブランチルールなど、GitHub Ruleset用のJSONテンプレートを格納しています。
-
 ### `.github/scripts/`
 
-Rulesetの適用、ブランチ自動削除、GitHub Project作成など、リポジトリセットアップを自動化するスクリプトを格納しています。詳細は [GITHUB_RULESET_SETUP.md](docs/GITHUB_RULESET_SETUP.md) を参照してください。
+ラベル設定やGitHub Project作成など、リポジトリセットアップを自動化するスクリプトを格納しています。
 
 ### `.github/dependabot.yml`
 
@@ -146,7 +142,8 @@ bash scripts/setup-git-hooks.sh
 
 ブランチ保護などの設定を適用する場合、以下のいずれかの方法で実行できます。
 
-> **補足**: `delete_branch_on_merge` / `allow_update_branch` は Terraform で管理します。
+> **補足**: Ruleset（branch protection / feature branch）と
+> `delete_branch_on_merge` / `allow_update_branch` は Terraform で管理します。
 > `.github/terraform/repository-settings/README.md` を参照してください。
 
 #### 方法1: GitHub Actions で実行（推奨）
@@ -165,22 +162,14 @@ bash scripts/setup-git-hooks.sh
 - Dry-run モードで事前確認可能
 - ローカル環境不要
 
-#### 方法2: ローカルでスクリプトを実行
+#### 方法2: Terraform をローカルで実行
 
 ```bash
-# すべての設定を一括で適用
-chmod +x .github/scripts/setup-all.sh
-./.github/scripts/setup-all.sh
-
-# または個別に適用
-chmod +x .github/scripts/setup-rulesets.sh
-./.github/scripts/setup-rulesets.sh
-
-chmod +x .github/scripts/setup-branch-auto-delete.sh
-./.github/scripts/setup-branch-auto-delete.sh
-
-chmod +x .github/scripts/setup-github-project.sh
-./.github/scripts/setup-github-project.sh
+cd .github/terraform/repository-settings
+terraform init
+terraform plan
+terraform apply
 ```
 
-詳細は [GITHUB_RULESET_SETUP.md](docs/GITHUB_RULESET_SETUP.md) を参照してください。
+詳細は [GITHUB_RULESET_SETUP.md](docs/GITHUB_RULESET_SETUP.md) と
+[.github/terraform/repository-settings/README.md](.github/terraform/repository-settings/README.md) を参照してください。

--- a/docs/GITHUB_RULESET_SETUP.md
+++ b/docs/GITHUB_RULESET_SETUP.md
@@ -1,187 +1,91 @@
 # GitHub Ruleset とブランチ保護設定ガイド
 
-このドキュメントでは、GitHub Ruleset とブランチ保護設定をテンプレート化して適用する方法を説明します。
-このテンプレートを取り込んだ他リポジトリでは不要だと思われます。必要に応じて削除してください。
+このドキュメントでは、GitHub Ruleset と関連するリポジトリ設定を
+Terraform で管理する方法を説明します。
+このテンプレートを取り込んだ他リポジトリでは不要だと思われます。
+必要に応じて削除してください。
 
 ## 概要
 
-GitHub Ruleset を使用することで、以下の設定をコード化して管理できます：
+GitHub の以下設定を Terraform でコード管理できます。
 
-- ブランチ保護ルール
-- プルリクエストの必須レビュー
-- ステータスチェックの必須化
-- ブランチ削除の制限
-- Bypass 設定（特定のユーザーやチームがルールを回避できる設定）
+- Branch Protection Ruleset（`main` / `develop` / `release/*`）
+- Feature Branch Ruleset（`feature/*` / `feat/*`）
+- `delete_branch_on_merge`
+- `allow_update_branch`
 
 ## 前提条件
 
-- GitHub CLI (gh) がインストールされていること
-- リポジトリへの管理者権限があること
-
-### GitHub CLI のインストール
-
-```bash
-# macOS
-brew install gh
-
-# Linux
-# https://cli.github.com/manual/installation を参照
-
-# Windows
-# https://cli.github.com/manual/installation を参照
-```
-
-### GitHub CLI へのログイン
-
-```bash
-gh auth login
-```
+- Terraform がインストールされていること
+- GitHub リポジトリへの管理者権限があること
+- リポジトリ設定変更可能な GitHub Personal Access Token を持っていること
 
 ## セットアップ方法
 
-### 方法1: 一括セットアップ（推奨）
+```bash
+cd .github/terraform/repository-settings
+terraform init
+```
 
-すべての設定を一度に適用する場合：
+環境変数を設定してください。
 
 ```bash
-chmod +x .github/scripts/setup-all.sh
-./.github/scripts/setup-all.sh
+export TF_VAR_github_owner="yellow-seed"
+export TF_VAR_repository_name="template"
+export TF_VAR_github_token="<PAT>"
 ```
 
-### 方法2: 個別セットアップ
+## 既存設定の import
 
-#### Ruleset の設定
+既存の設定を Terraform 管理へ移行する場合は、先に import してください。
 
 ```bash
-chmod +x .github/scripts/setup-rulesets.sh
-./.github/scripts/setup-rulesets.sh
+terraform import github_repository.template template
+terraform import github_repository_ruleset.branch_protection <branch-protection-ruleset-id>
+terraform import github_repository_ruleset.feature_branch <feature-branch-ruleset-id>
 ```
 
-このスクリプトは以下の Ruleset を適用します：
-
-- **Branch Protection Ruleset**: `main`, `develop`, `release/*` ブランチ用
-  - プルリクエスト必須
-  - 1名以上の承認必須
-  - CI ステータスチェック必須
-  - ブランチ削除保護
-  - 組織管理者は Bypass 可能
-
-- **Feature Branch Ruleset**: `feature/*`, `feat/*` ブランチ用
-  - プルリクエスト必須
-  - 1名以上の承認必須
-  - ステータスチェックは任意
-
-#### リポジトリ基本設定（Terraform 管理）
-
-`delete_branch_on_merge` と `allow_update_branch` は Terraform で管理します。
-手順は `.github/terraform/repository-settings/README.md` を参照してください。
-
-## Ruleset テンプレートのカスタマイズ
-
-### ブランチ保護 Ruleset のカスタマイズ
-
-`.github/rulesets/branch-protection-ruleset.json` を編集して、以下の設定を変更できます：
-
-#### 対象ブランチの変更
-
-```json
-{
-  "conditions": {
-    "ref_name": {
-      "include": ["main", "develop", "release/*"]
-    }
-  }
-}
-```
-
-#### 必須レビュー数の変更
-
-```json
-{
-  "rules": [
-    {
-      "type": "pull_request",
-      "parameters": {
-        "required_approving_review_count": 2 // 2名以上の承認を必須にする
-      }
-    }
-  ]
-}
-```
-
-#### Bypass 設定の変更
-
-```json
-{
-  "bypass_actors": [
-    {
-      "actor_id": 123456, // チームIDまたはユーザーID
-      "actor_type": "Team", // Team, Integration, OrganizationAdmin
-      "bypass_mode": "always" // always, pull_request
-    }
-  ]
-}
-```
-
-**Bypass Actor の ID を取得する方法：**
+Ruleset ID は GitHub CLI で確認できます。
 
 ```bash
-# チームIDを取得
-gh api orgs/OWNER/teams --jq '.[] | select(.name == "TEAM_NAME") | {id: .id, name: .name}'
-
-# ユーザーIDを取得
-gh api users/USERNAME --jq '{id: .id, login: .login}'
+gh api repos/OWNER/REPO/rulesets --jq '.[] | {id: .id, name: .name}'
 ```
 
-### Feature Branch Ruleset のカスタマイズ
-
-`.github/rulesets/feature-branch-ruleset.json` を編集して、フィーチャーブランチ用のルールをカスタマイズできます。
-
-## 手動設定（UI を使用する場合）
-
-スクリプトを使用しない場合は、GitHub の Web UI から手動で設定することもできます。
-
-### Ruleset の手動設定
-
-1. リポジトリの Settings > Rules > Rulesets に移動
-2. "New ruleset" をクリック
-3. "New branch ruleset" を選択
-4. `.github/rulesets/` 内の JSON ファイルの内容を参考に設定
-
-## 既存の Ruleset の確認
+## 差分確認と適用
 
 ```bash
-# すべての Ruleset を一覧表示
-gh api repos/OWNER/REPO/rulesets --jq '.[] | {id: .id, name: .name, enforcement: .enforcement}'
-
-# 特定の Ruleset の詳細を表示
-gh api repos/OWNER/REPO/rulesets/RULESET_ID
+terraform plan
+terraform apply
 ```
 
-## トラブルシューティング
+移行後は `terraform plan` でゼロ差分になることを確認してください。
 
-### 権限エラー
+## 管理中の Ruleset 内容
 
-リポジトリへの管理者権限が必要です。権限を確認してください：
+### Branch Protection Ruleset
 
-```bash
-gh api repos/OWNER/REPO --jq '.permissions'
-```
+- 対象: `refs/heads/main`, `refs/heads/develop`, `refs/heads/release/*`
+- Pull Request 必須
+- 承認 1 名以上
+- stale review dismiss 有効
+- status check `ci` 必須（strict）
+- non-fast-forward / deletion / update 制御
+- `RepositoryRole`（actor_id: 5）の bypass 設定あり
 
-### Ruleset が適用されない
+### Feature Branch Ruleset
 
-1. Ruleset の `enforcement` が `active` になっているか確認
-2. ブランチ名が `conditions.ref_name.include` のパターンに一致しているか確認
-3. Ruleset の順序を確認（複数の Ruleset がある場合、最初に一致したものが適用されます）
+- 対象: `refs/heads/feature/*`, `refs/heads/feat/*`
+- Pull Request 必須
+- 承認 1 名以上
+- stale review dismiss 有効
+- `RepositoryRole`（actor_id: 5）の bypass 設定あり
 
-### Bypass が機能しない
+## 補足
 
-1. `actor_id` が正しいか確認
-2. `actor_type` が正しいか確認（Team, Integration, OrganizationAdmin）
-3. `bypass_mode` が適切か確認（`always` または `pull_request`）
+旧 Ruleset JSON と `setup-rulesets.sh` は互換目的で残してあります。
+実運用では Terraform 側を正としてください。
 
 ## 参考資料
 
+- [Terraform GitHub Provider](https://registry.terraform.io/providers/integrations/github/latest/docs)
 - [GitHub Rulesets API ドキュメント](https://docs.github.com/en/rest/repos/rules)
-- [Creating rulesets for a repository](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/creating-rulesets-for-a-repository)
-- [GitHub CLI ドキュメント](https://cli.github.com/manual/)

--- a/tests/codex-setup.bats
+++ b/tests/codex-setup.bats
@@ -22,7 +22,8 @@ setup() {
     "$WORK_DIR/.codex/hooks/gh-setup.sh" \
     "$WORK_DIR/.codex/hooks/env-setup.sh" \
     "$WORK_DIR/.claude/hooks/skills-setup.sh" \
-    "$WORK_DIR/scripts/setup-git-hooks.sh"; do
+    "$WORK_DIR/scripts/setup-git-hooks.sh" \
+    "$WORK_DIR/scripts/install-tools.sh"; do
     printf '#!/bin/bash\nexit 0\n' >"$stub"
     chmod +x "$stub"
   done
@@ -34,6 +35,10 @@ setup() {
 
 teardown() {
   rm -rf "$WORK_DIR"
+}
+
+@test "codex-setup.sh installs tools via scripts/install-tools.sh" {
+  grep -q 'scripts/install-tools.sh' "$SCRIPT"
 }
 
 @test "codex-setup.sh contains CODEX_REMOTE-guarded git remote remove step" {


### PR DESCRIPTION
### Motivation

- Move GitHub Ruleset and repository settings management to Terraform for more reliable, auditable configuration. 
- Ensure local Codex environment setup installs required developer tools in a predictable step and avoid duplicate installs when invoked from higher-level setup. 

### Description

- Add Terraform resources for repository rulesets in `.github/terraform/repository-settings/main.tf`, creating a Branch Protection Ruleset and a Feature Branch Ruleset and wiring them to `github_repository.template`. 
- Update documentation in `README.md`, `.github/terraform/repository-settings/README.md`, and `docs/GITHUB_RULESET_SETUP.md` to document the Terraform-based workflow and import/apply steps. 
- Integrate `scripts/install-tools.sh` into `.codex/hooks/codex-setup.sh` as an explicit installation step and adjust log step numbers and ordering accordingly. 
- Add a `CODEX_SKIP_TOOL_INSTALL` guard in `.codex/hooks/env-setup.sh` so `install-tools.sh` can be skipped when already run by the caller, and export `INSTALL_PREFIX`, `ENV_FILE`, and `STRICT_MODE` defaults. 
- Simplify `.github/scripts/setup-all.sh` to focus on label and project setup and update messaging to reflect that Rulesets and repository settings are managed by Terraform. 
- Update tests to account for the new install step by stubbing `scripts/install-tools.sh` and adding an assertion for its presence in the Codex setup script. 

### Testing

- Ran `bats tests/codex-setup.bats` which exercises `.codex/hooks/codex-setup.sh` behavior and the new `scripts/install-tools.sh` integration, and the tests passed. 
- Ran `.github/scripts/tests/setup-all.bats` to validate `setup-all.sh` structure and invocation of label/project scripts, and the tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0a2e316e0832d8b35aac7d20f3ae7)

## Summary by Sourcery

Manage GitHub repository rulesets and core protection settings via Terraform and integrate a dedicated tool installation step into the Codex setup flow.

New Features:
- Define Terraform-managed GitHub repository rulesets for branch protection and feature branches tied to the template repository.
- Add an explicit development tool installation step to the Codex setup using scripts/install-tools.sh with configurable defaults and skip control.

Enhancements:
- Document the Terraform-based workflow for managing rulesets and repository settings, including import and apply procedures.
- Simplify the GitHub setup-all script to only configure labels and GitHub Projects while delegating rulesets and protection settings to Terraform.
- Adjust Codex environment setup to optionally skip tool installation when already handled by the caller and to export common environment variables.

Tests:
- Update Codex setup Bats tests to stub the new install-tools script and assert its invocation.
- Simplify setup-all Bats tests to align with the reduced responsibility of the setup-all script.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool installation phase can now be skipped via configuration flag during setup.

* **Improvements**
  * Reorganized setup process with clearer step progression and labels.
  * Shifted repository protection settings to Terraform-based management for improved consistency.

* **Documentation**
  * Updated setup instructions to reflect Terraform-driven workflow for branch protection and feature branch rulesets.
  * Clarified that ruleset configuration is now handled through infrastructure-as-code management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->