### PR TITLE
fix: exclude mirrored skill directories from qlty prettier

### DIFF
--- a/.qlty/qlty.toml
+++ b/.qlty/qlty.toml
@@ -26,4 +26,4 @@ version = "3.6.2"
 
 [[exclude]]
 plugins = ["prettier"]
-file_patterns = [".github/skills/**"]
+file_patterns = [".github/skills/**", ".claude/skills/**", ".codex/skills/**"]


### PR DESCRIPTION
### Motivation

- Prevent `qlty` Prettier from redundantly checking mirrored skill files under `.claude/skills` and `.codex/skills` so the `qlty Lint` failure reported for issue #242 is resolved.

### Description

- Add `.claude/skills/**` and `.codex/skills/**` to the Prettier exclude `file_patterns` in `.qlty/qlty.toml` to avoid duplicate linting of `.github/skills/**`; Close #242.

### Testing

- Installed `qlty` and ran `qlty check --all` (with `~/.qlty/bin` on `PATH`) and `qlty fmt --all`, which reported `✔ No issues`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0e5f311bc832d9c0a7f7e8a0cef48)

## Summary by Sourcery

Build:
- Extend qlty Prettier exclude patterns to skip .claude/skills and .codex/skills directories to prevent redundant checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration to exclude additional directories from quality checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->