### PR TITLE
chore: add .mise.toml to centralize tool versions

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,4 @@
+[tools]
+bats = "1.11.1"
+dotenvx = "latest"
+terraform = "1.11.4"


### PR DESCRIPTION
### Motivation
- Centralize installer tool versions for `bats`, `dotenvx`, and `terraform` so installer scripts can reference a single source of truth and satisfy Issue #230.

### Description
- Add a new root-level `.mise.toml` containing a `[tools]` section with `bats = "1.11.1"`, `dotenvx = "latest"`, and `terraform = "1.11.4"`; Close #230.

### Testing
- Ran `mise trust .mise.toml`, `mise install`, and `mise ls` to verify the specified tools were recognized and installed (operations completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1787b6844832d8b2c6b6bda0cd58b)

## Summary by Sourcery

Build:
- Introduce a .mise.toml file at the repository root to define shared versions for bats, dotenvx, and terraform.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added development tool configuration to standardize and manage dependencies for the build and testing environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->