### PR TITLE
chore: migrate bats CI setup to mise-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Install bats tooling
-        run: SKIP_INSTALLERS=qlty STRICT_MODE=true bash scripts/install-tools.sh
+      - name: Setup mise
+        uses: jdx/mise-action@v2
 
       - name: Run bats tests
         run: bats tests/*.bats

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,4 @@
+[tools]
+bats = "1.11.1"
+dotenvx = "latest"
+terraform = "1.11.4"


### PR DESCRIPTION
### Motivation

- Replace the ad-hoc `scripts/install-tools.sh` invocation in the `bats Test` CI job with the `jdx/mise-action` setup to rely on `.mise.toml` managed tool versions. 
- Centralize tool version definitions for `bats`, `dotenvx`, and `terraform` to satisfy the CI migration requirements in Issue #231.

### Description

- Updated `.github/workflows/ci.yml` to replace the `Install bats tooling` step with `jdx/mise-action@v2` in the `bats Test` job. 
- Added a new `.mise.toml` at the repository root that defines `bats = "1.11.1"`, `dotenvx = "latest"`, and `terraform = "1.11.4"`. 
- Commit message: `chore: migrate bats CI setup to mise-action` and this PR closes the related issue: `Closes #231`.

### Testing

- Ran `bash scripts/install-tools.sh` locally to verify installers complete, and it finished successfully. 
- Executed `bats tests/*.bats` and all tests passed (`1..12`, all `ok`). 
- Attempted `qlty` validation (`qlty check .github/workflows/ci.yml .mise.toml`) but the check did not complete in this environment and could not be fully verified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1788f2114832d972432c20ea270cb)

## Summary by Sourcery

Migrate the bats CI job to use mise for tool installation and configuration.

Build:
- Introduce a .mise.toml file to centralize version-managed tools (bats, dotenvx, terraform).

CI:
- Replace the custom bats tooling installation step in the CI workflow with the jdx/mise-action setup.