### PR TITLE
fix: ensure origin remote in gh setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,9 @@ bash .claude/hooks/skills-setup.sh
 
 このスクリプトは`.github/skills`を`.claude/skills`と`.codex/skills`にコピーします。
 
+また、リモート環境向けの`gh-setup`では`origin`リモートが未設定の場合に
+`GITHUB_REPOSITORY`（または関連設定）から自動構成します。
+
 **注意事項**:
 
 - シンボリックリンク環境では、すべてのディレクトリは自動的に同期されます

--- a/scripts/gh-setup.sh
+++ b/scripts/gh-setup.sh
@@ -37,6 +37,90 @@ install_gh_extensions() {
 	install_gh_extension "$gh_cmd" "harakeishi/gh-discussion"
 }
 
+extract_repo_slug() {
+	local value="$1"
+
+	if [ -z "$value" ]; then
+		return 1
+	fi
+
+	value="${value#git@}"
+	value="${value#ssh://git@}"
+	value="${value#https://}"
+	value="${value#http://}"
+	value="${value#*/}"
+	value="${value#*:}"
+	value="${value%.git}"
+
+	if [[ "$value" =~ ^[^/]+/[^/]+$ ]]; then
+		echo "$value"
+		return 0
+	fi
+
+	return 1
+}
+
+resolve_repository_slug() {
+	local repository="${GITHUB_REPOSITORY:-}"
+
+	if [ -n "$repository" ]; then
+		echo "$repository"
+		return 0
+	fi
+
+	if repository=$(git config --get remote.upstream.url 2>/dev/null); then
+		extract_repo_slug "$repository" && return 0
+	fi
+
+	if repository=$(git config --get github.repository 2>/dev/null); then
+		extract_repo_slug "$repository" && return 0
+	fi
+
+	return 1
+}
+
+resolve_remote_base_url() {
+	if [ -n "${GITHUB_REMOTE_URL_BASE:-}" ]; then
+		echo "${GITHUB_REMOTE_URL_BASE%/}"
+		return 0
+	fi
+
+	if [ -n "${GITHUB_SERVER_URL:-}" ]; then
+		echo "${GITHUB_SERVER_URL%/}"
+		return 0
+	fi
+
+	echo "https://github.com"
+}
+
+ensure_origin_remote() {
+	if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+		log "Not in a git repository, skipping origin remote setup"
+		return 0
+	fi
+
+	if git remote get-url origin >/dev/null 2>&1; then
+		log "origin remote already configured, skipping"
+		return 0
+	fi
+
+	local repository
+	if ! repository=$(resolve_repository_slug); then
+		log "Could not resolve repository slug, skipping origin remote setup"
+		return 0
+	fi
+
+	local base_url
+	base_url=$(resolve_remote_base_url)
+	local origin_url="${base_url}/${repository}.git"
+
+	if git remote add origin "$origin_url"; then
+		log "Configured origin remote: $origin_url"
+	else
+		log "Failed to configure origin remote (non-critical, continuing)"
+	fi
+}
+
 if [ -z "${REMOTE_ENV_VAR:-}" ]; then
 	log "REMOTE_ENV_VAR is not set, skipping gh setup"
 	exit 0
@@ -47,6 +131,8 @@ if [ "$REMOTE_ENV_VALUE" != "true" ]; then
 	log "Not a remote session, skipping gh setup"
 	exit 0
 fi
+
+ensure_origin_remote
 
 log "Remote session detected, checking gh CLI..."
 

--- a/tests/gh-setup.bats
+++ b/tests/gh-setup.bats
@@ -36,6 +36,10 @@ GH
   export PATH="$WORK_DIR/bin:$PATH"
   export REMOTE_ENV_VAR="TEST_REMOTE"
   export TEST_REMOTE=true
+
+  export TEST_REPO="$WORK_DIR/repo"
+  mkdir -p "$TEST_REPO"
+  git init "$TEST_REPO" >/dev/null
 }
 
 teardown() {
@@ -65,4 +69,42 @@ EXT
   run awk '/^extension install / { count++ } END { print count + 0 }' "$GH_LOG"
   [ "$status" -eq 0 ]
   [ "$output" -eq 0 ]
+}
+
+@test "gh-setup configures origin from GITHUB_REPOSITORY when missing" {
+  cd "$TEST_REPO"
+  export GITHUB_REPOSITORY="yellow-seed/template"
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+
+  run git remote get-url origin
+  [ "$status" -eq 0 ]
+  [ "$output" = "https://github.com/yellow-seed/template.git" ]
+}
+
+@test "gh-setup does not overwrite existing origin" {
+  cd "$TEST_REPO"
+  git remote add origin "https://example.com/custom/repo.git"
+  export GITHUB_REPOSITORY="yellow-seed/template"
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+
+  run git remote get-url origin
+  [ "$status" -eq 0 ]
+  [ "$output" = "https://example.com/custom/repo.git" ]
+}
+
+@test "gh-setup uses custom remote base URL when provided" {
+  cd "$TEST_REPO"
+  export GITHUB_REPOSITORY="yellow-seed/template"
+  export GITHUB_REMOTE_URL_BASE="https://proxy.local/github"
+
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+
+  run git remote get-url origin
+  [ "$status" -eq 0 ]
+  [ "$output" = "https://proxy.local/github/yellow-seed/template.git" ]
 }


### PR DESCRIPTION
### Motivation

- Remote sessions can start with no `origin` configured which breaks agent workflows that expect a Git remote, so the setup script should ensure `origin` exists when appropriate.

### Description

- Add idempotent origin bootstrapping to `scripts/gh-setup.sh` via `ensure_origin_remote` which only adds `origin` when missing and preserves existing remotes.
- Implement helper functions `extract_repo_slug`, `resolve_repository_slug`, and `resolve_remote_base_url` to resolve repository slug and base URL from `GITHUB_REPOSITORY`, git config, or environment variables, and compose the origin URL as `<base>/<owner>/<repo>.git`.
- Invoke `ensure_origin_remote` during remote setup and keep existing `gh` extension installation behavior unchanged; changes are in `scripts/gh-setup.sh` and documented in `AGENTS.md`.
- Add tests to `tests/gh-setup.bats` covering origin configuration, non-overwrite behavior, and custom remote base URL usage, and update documentation accordingly; Close #224

### Testing

- Ran a shell syntax check with `bash -n scripts/gh-setup.sh tests/gh-setup.bats .claude/hooks/gh-setup.sh scripts/setup-git-hooks.sh` which succeeded.
- Executing `bats tests/gh-setup.bats` was attempted but could not run in this environment because `bats` is not installed (failure due to missing test runner).
- Performed an automated functional verification by creating a temporary git repo and stubbed `gh` binary and running `scripts/gh-setup.sh`, which successfully configured `origin` as expected for the covered scenarios.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1786c15a4832dbf5f3e244cefdc03)

## Summary by Sourcery

Ensure remote GitHub setup script configures a default origin remote for remote environments while keeping existing remotes intact.

New Features:
- Automatically configure an origin remote in remote environments when none exists, deriving the repository slug and base URL from environment or git settings.

Bug Fixes:
- Prevent agent workflows from failing in remote sessions that start without an origin remote configured.

Enhancements:
- Add utility functions to resolve the repository slug and remote base URL in a robust, environment-aware way.
- Document the origin auto-configuration behavior for remote gh setup in AGENTS.md.

Tests:
- Extend gh-setup Bats tests to cover origin auto-configuration, non-overwrite behavior, and custom remote base URL usage.