### PR TITLE
fix: fall back to individual installers when mise does not install tools

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,4 @@
+[tools]
+bats = "1.11.1"
+dotenvx = "latest"
+terraform = "1.11.4"

--- a/scripts/install-tools.sh
+++ b/scripts/install-tools.sh
@@ -64,6 +64,17 @@ main() {
 	for installer in "${mise_managed_installers[@]}"; do
 		if should_skip "$installer"; then
 			log "Skipping $installer (SKIP_INSTALLERS)"
+			continue
+		fi
+		if ! command_exists "$installer"; then
+			log "Falling back to individual installer for $installer (not found after mise install)"
+			if ! bash "$ORCHESTRATOR_DIR/installers/${installer}.sh"; then
+				had_failure=true
+				fail "Installer failed: $installer"
+				if [ "$STRICT_MODE" != "true" ]; then
+					log "Continuing after failure because STRICT_MODE=$STRICT_MODE"
+				fi
+			fi
 		fi
 	done
 

--- a/scripts/run-checks.sh
+++ b/scripts/run-checks.sh
@@ -2,4 +2,8 @@
 set -u
 set -o pipefail
 
-exec qlty check --all "$@"
+if [ "$#" -eq 0 ]; then
+	exec qlty check --all
+else
+	exec qlty check "$@"
+fi

--- a/tests/install-tools-orchestrator.bats
+++ b/tests/install-tools-orchestrator.bats
@@ -13,16 +13,21 @@ setup() {
   export INSTALL_LOG="$WORK_DIR/installers.log"
   : >"$INSTALL_LOG"
 
-  for cmd in bash dirname mkdir mktemp rm id touch; do
+  for cmd in bash cat chmod dirname mkdir mktemp rm id touch; do
     ln -s "$(command -v "$cmd")" "$WORK_DIR/bin/$cmd"
   done
 
+  # mise stub: installer creates mise binary that simulates installing managed tools into PATH
   cat >"$WORK_DIR/scripts/installers/mise.sh" <<'SCRIPT'
 #!/bin/bash
 echo "mise-installer" >>"$INSTALL_LOG"
 cat >"$WORK_DIR/bin/mise" <<'MISE'
 #!/bin/bash
 echo "mise-install" >>"$INSTALL_LOG"
+for tool in bats dotenvx terraform; do
+  echo "#!/bin/bash" >"$WORK_DIR/bin/$tool"
+  chmod +x "$WORK_DIR/bin/$tool"
+done
 MISE
 chmod +x "$WORK_DIR/bin/mise"
 SCRIPT
@@ -54,6 +59,7 @@ teardown() {
   run grep -x "qlty" "$INSTALL_LOG"
   [ "$status" -eq 0 ]
 
+  # bats and terraform are installed by mise into PATH, so individual installers should not be called
   run grep -x "terraform" "$INSTALL_LOG"
   [ "$status" -ne 0 ]
 
@@ -73,4 +79,37 @@ teardown() {
 
   run grep -x "qlty" "$INSTALL_LOG"
   [ "$status" -ne 0 ]
+}
+
+@test "install-tools falls back to individual installer when mise does not install the tool" {
+  # Override mise stub: mise installs but does NOT put managed tools into PATH
+  cat >"$WORK_DIR/scripts/installers/mise.sh" <<'SCRIPT'
+#!/bin/bash
+echo "mise-installer" >>"$INSTALL_LOG"
+cat >"$WORK_DIR/bin/mise" <<'MISE'
+#!/bin/bash
+echo "mise-install" >>"$INSTALL_LOG"
+MISE
+chmod +x "$WORK_DIR/bin/mise"
+SCRIPT
+  chmod +x "$WORK_DIR/scripts/installers/mise.sh"
+
+  run env -i PATH="$WORK_DIR/bin" HOME="$HOME" INSTALL_LOG="$INSTALL_LOG" WORK_DIR="$WORK_DIR" bash "$WORK_DIR/scripts/install-tools.sh"
+  [ "$status" -eq 0 ]
+
+  run grep -x "mise-installer" "$INSTALL_LOG"
+  [ "$status" -eq 0 ]
+
+  run grep -x "mise-install" "$INSTALL_LOG"
+  [ "$status" -eq 0 ]
+
+  # bats and terraform individual installers called as fallback
+  run grep -x "bats" "$INSTALL_LOG"
+  [ "$status" -eq 0 ]
+
+  run grep -x "terraform" "$INSTALL_LOG"
+  [ "$status" -eq 0 ]
+
+  run grep -x "qlty" "$INSTALL_LOG"
+  [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
## Motivation

PR #245 の `bats Test` CI が `bats: command not found` (exit code 127) で失敗している。

## 原因

`scripts/install-tools.sh` の `mise`-first フローに 2 つの問題があった：

1. **個別インストーラーへのフォールバックがない**  
   `mise_managed_installers` ループが SKIP_INSTALLERS のログ出力しかしておらず、`mise install` がツールをインストールしなかった場合でも個別インストーラー（`bats.sh` 等）を呼ばない。CI 環境（`ubuntu-latest`）には `.mise.toml` がないため `mise install` はノーオペレーションとなり、`bats` がインストールされない。

2. **`scripts/run-checks.sh` と `--all` フラグの競合**  
   `qlty check --all` はファイルパス引数と併用できないが、pre-commit フックがファイルパスを渡して呼んでいた。

## 対応内容

### `scripts/install-tools.sh`
- `mise_managed_installers` ループに `command_exists` チェックを追加
- `mise install` 後にツールが PATH に存在しない場合、個別インストーラーをフォールバックとして呼ぶ

### `tests/install-tools-orchestrator.bats`
- `mise` スタブを更新：`mise install` でマネージドツール（bats/dotenvx/terraform）を PATH に追加するよう模倣
- テスト環境の制限 PATH に `cat` / `chmod` を追加
- フォールバック動作を検証する新しいテストケースを追加

### `scripts/run-checks.sh`
- ファイルパスが渡された場合は `--all` なしで `qlty check <files>` を実行するよう修正

## Testing

ローカルで全 bats テストがパスすることを確認（13/13）

https://claude.ai/code/session_012pvguTyVn2svY6eznoR7Kn

## Summary by Sourcery

Ensure tool installation falls back to individual installers when mise does not place tools on PATH and adjust checks script to handle file arguments correctly.

Bug Fixes:
- Fix missing fallback to individual installers when mise does not install or expose managed tools on PATH.
- Fix run-checks script so qlty is invoked with --all only when no file paths are provided.

Tests:
- Extend install-tools orchestrator tests with a stubbed mise implementation and new cases verifying fallback behavior and PATH handling.