### PR TITLE
chore: add .mise.toml for tool version management

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,4 @@
+[tools]
+bats = "1.11.1"
+dotenvx = "latest"
+terraform = "1.11.4"

--- a/scripts/installers/_common.sh
+++ b/scripts/installers/_common.sh
@@ -68,6 +68,34 @@ trim() {
 	printf '%s' "$value"
 }
 
+get_mise_tool_version() {
+	local tool="$1"
+	local config_path="${REPO_ROOT}/.mise.toml"
+
+	if [ ! -f "$config_path" ]; then
+		return 1
+	fi
+
+	awk -F'=' -v tool="$tool" '
+		BEGIN { in_tools = 0 }
+		/^[[:space:]]*\[/ {
+			in_tools = ($0 ~ /^[[:space:]]*\[tools\][[:space:]]*$/)
+			next
+		}
+		in_tools {
+			key = $1
+			gsub(/^[[:space:]]+|[[:space:]]+$/, "", key)
+			if (key == tool) {
+				value = $2
+				gsub(/^[[:space:]]+|[[:space:]]+$/, "", value)
+				gsub(/^"|"$/, "", value)
+				print value
+				exit
+			}
+		}
+	' "$config_path"
+}
+
 install_packages() {
 	local packages=("$@")
 	local sudo_cmd

--- a/scripts/installers/bats.sh
+++ b/scripts/installers/bats.sh
@@ -16,26 +16,32 @@ main() {
 		version="${BATS_VERSION#v}"
 		log "Using bats-core version from BATS_VERSION: ${version}"
 	else
-		log "Fetching latest bats-core version..."
-
-		local version_json
-		if [ -n "${GITHUB_TOKEN:-}" ]; then
-			version_json=$(curl -fsSL -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-				https://api.github.com/repos/bats-core/bats-core/releases/latest 2>/dev/null)
+		version=$(get_mise_tool_version bats || true)
+		if [ -n "$version" ] && [ "$version" != "latest" ]; then
+			version="${version#v}"
+			log "Using bats-core version from .mise.toml: ${version}"
 		else
-			version_json=$(curl -fsSL \
-				https://api.github.com/repos/bats-core/bats-core/releases/latest 2>/dev/null)
-		fi
+			log "Fetching latest bats-core version..."
 
-		if [ -z "${version_json:-}" ]; then
-			fail "failed to fetch latest bats-core release info; consider setting GITHUB_TOKEN or BATS_VERSION"
-			return 1
-		fi
+			local version_json
+			if [ -n "${GITHUB_TOKEN:-}" ]; then
+				version_json=$(curl -fsSL -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+					https://api.github.com/repos/bats-core/bats-core/releases/latest 2>/dev/null)
+			else
+				version_json=$(curl -fsSL \
+					https://api.github.com/repos/bats-core/bats-core/releases/latest 2>/dev/null)
+			fi
 
-		version=$(printf '%s' "$version_json" | grep '"tag_name"' | head -n1 | sed 's/.*"tag_name": *"v\([^"]*\)".*/\1/')
-		if [ -z "$version" ]; then
-			fail "could not parse bats-core version from GitHub API response; consider setting BATS_VERSION"
-			return 1
+			if [ -z "${version_json:-}" ]; then
+				fail "failed to fetch latest bats-core release info; consider setting GITHUB_TOKEN or BATS_VERSION"
+				return 1
+			fi
+
+			version=$(printf '%s' "$version_json" | grep '"tag_name"' | head -n1 | sed 's/.*"tag_name": *"v\([^"]*\)".*/\1/')
+			if [ -z "$version" ]; then
+				fail "could not parse bats-core version from GitHub API response; consider setting BATS_VERSION"
+				return 1
+			fi
 		fi
 	fi
 

--- a/scripts/installers/terraform.sh
+++ b/scripts/installers/terraform.sh
@@ -20,7 +20,9 @@ main() {
 
 	detect_arch || return 1
 	local arch="$GO_ARCH"
-	local version="${TERRAFORM_VERSION:-1.11.4}"
+	local mise_version
+	mise_version=$(get_mise_tool_version terraform || true)
+	local version="${TERRAFORM_VERSION:-${mise_version:-1.11.4}}"
 	local os="linux"
 	local zip_name="terraform_${version}_${os}_${arch}.zip"
 	local download_url="https://releases.hashicorp.com/terraform/${version}/${zip_name}"

--- a/tests/install-tools.bats
+++ b/tests/install-tools.bats
@@ -44,3 +44,25 @@ teardown() {
   [ -n "$install_line" ]
   [ "$update_line" -lt "$install_line" ]
 }
+
+@test "get_mise_tool_version reads tool version from .mise.toml" {
+  cat > "$WORK_DIR/.mise.toml" <<'MISE'
+[tools]
+terraform = "1.11.4"
+MISE
+
+  run bash -c "source '$REPO_ROOT/scripts/installers/_common.sh'; REPO_ROOT='$WORK_DIR'; get_mise_tool_version terraform"
+  [ "$status" -eq 0 ]
+  [ "$output" = "1.11.4" ]
+}
+
+@test "get_mise_tool_version returns empty when tool is not defined" {
+  cat > "$WORK_DIR/.mise.toml" <<'MISE'
+[tools]
+bats = "1.11.1"
+MISE
+
+  run bash -c "source '$REPO_ROOT/scripts/installers/_common.sh'; REPO_ROOT='$WORK_DIR'; get_mise_tool_version terraform"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}


### PR DESCRIPTION
### Motivation

- Centralize installer tool versions so multiple installer scripts do not hardcode different defaults and to make CI/maintenance easier.

### Description

- Add project-level `.mise.toml` with `bats`, `dotenvx`, and `terraform` entries to centralize versions; this file is present at project root and lists default versions. Close #230
- Add `get_mise_tool_version` helper in `scripts/installers/_common.sh` to read the `[tools]` section of `.mise.toml` for a given tool name.
- Update `scripts/installers/bats.sh` to prefer a version from `.mise.toml` when `BATS_VERSION` is not set and fall back to querying GitHub Releases only if not defined.
- Update `scripts/installers/terraform.sh` to use the `.mise.toml` value as the default when `TERRAFORM_VERSION` is not set, falling back to the previous hardcoded default when absent.
- Add Bats tests in `tests/install-tools.bats` to validate `get_mise_tool_version` behavior.

### Testing

- Ran a shell syntax check with `bash -n` on the modified installer scripts which completed successfully.
- Added Bats tests and attempted to run them with `bats tests/...`, but the test run failed in this environment due to the test runner binary not being available and `mise` config trust warnings, so the new tests could not be executed end-to-end here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b343d1c34c832d9f21f4f87a1edc81)

## Summary by Sourcery

Centralize installer tool versions using a shared .mise.toml configuration and have installers prefer these versions when available.

Enhancements:
- Add a project-level .mise.toml file defining default versions for bats, dotenvx, and terraform.
- Introduce a get_mise_tool_version helper in the shared installer script to read tool versions from .mise.toml.
- Update bats and terraform installer scripts to use .mise.toml-defined versions as their default when explicit environment variables are not set.

Tests:
- Add Bats tests to verify get_mise_tool_version behavior for defined and undefined tools in .mise.toml.